### PR TITLE
Feature/reduce-noise

### DIFF
--- a/.changeset/quiet-books-dance.md
+++ b/.changeset/quiet-books-dance.md
@@ -1,0 +1,10 @@
+---
+"effect-analyzer": patch
+---
+
+Fix Mermaid rendering edge cases to reduce diagram noise and improve correctness.
+
+- Remove duplicate type annotations from node labels.
+- Emit only `classDef` styles that are actually referenced by rendered nodes.
+- Prevent duplicate yield nodes from breaking conditional branch diagrams.
+- Avoid orphan rectangular nodes for decision flows.

--- a/packages/effect-analyzer/src/__fixtures__/early-return-fail.test.ts
+++ b/packages/effect-analyzer/src/__fixtures__/early-return-fail.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Effect } from 'effect';
+import { analyze } from '../analyze';
+import { resolve } from 'path';
+import type {
+  StaticEffectIR,
+  StaticFlowNode,
+  StaticGeneratorNode,
+  StaticDecisionNode,
+  StaticTerminalNode,
+} from '../types';
+import { renderMermaid } from '../output/mermaid';
+
+const FIXTURE_PATH = resolve(__dirname, 'early-return-fail.ts');
+
+describe('Early return with Effect.fail - conditional branch fix', () => {
+  let programsByName: Map<string, StaticEffectIR>;
+
+  beforeAll(async () => {
+    const results = await Effect.runPromise(
+      analyze(FIXTURE_PATH).all(),
+    );
+    programsByName = new Map(
+      results.map((ir) => [ir.root.programName, ir]),
+    );
+  }, 30_000);
+
+  it('should produce correct IR: decision has no onFalse, success is a sibling', () => {
+    const ir = programsByName.get('earlyReturnFail');
+    expect(ir).toBeDefined();
+
+    const gen = ir!.root.children.find(
+      (n): n is StaticGeneratorNode => n.type === 'generator',
+    );
+    expect(gen).toBeDefined();
+
+    const yields = gen!.yields;
+    const decisionIdx = yields.findIndex(y => y.effect.type === 'decision');
+    expect(decisionIdx).toBeGreaterThanOrEqual(0);
+
+    const decision = yields[decisionIdx]!.effect as StaticDecisionNode;
+
+    // onTrue should contain the error path (terminal return with fail)
+    expect(decision.onTrue.length).toBeGreaterThan(0);
+    expect(decision.onTrue.some(n => n.type === 'terminal')).toBe(true);
+
+    // onFalse should be undefined — there is no else branch
+    expect(decision.onFalse).toBeUndefined();
+
+    // The success continuation should be AFTER the decision in the yields array,
+    // NOT duplicated or misplaced inside onFalse
+    const afterDecision = yields.slice(decisionIdx + 1);
+    expect(afterDecision.length).toBeGreaterThan(0);
+
+    // The success path should NOT contain a fail node
+    const afterTypes = afterDecision.map(y => (y.effect as any).callee || y.effect.type);
+    expect(afterTypes).not.toContain('Effect.fail');
+  });
+
+  it('should not duplicate yielded calls in the non-yielded scanner', () => {
+    const ir = programsByName.get('earlyReturnFail');
+    expect(ir).toBeDefined();
+
+    const gen = ir!.root.children.find(
+      (n): n is StaticGeneratorNode => n.type === 'generator',
+    );
+    expect(gen).toBeDefined();
+
+    // Count how many Effect.succeed nodes appear in the yields.
+    // The fixture has 3 yield* Effect.succeed calls + 1 yield* Effect.fail.
+    // Without deduplication, the non-yielded scanner would add duplicates.
+    const effectNodes = gen!.yields.filter(
+      y => y.effect.type === 'effect',
+    );
+    const succeedCount = effectNodes.filter(
+      y => (y.effect as any).callee === 'Effect.succeed',
+    ).length;
+    // Exactly 3: balance, amount, result (no duplicates)
+    expect(succeedCount).toBe(3);
+
+    // No fail nodes should appear as top-level yields (fail is inside the decision's onTrue)
+    const failCount = effectNodes.filter(
+      y => (y.effect as any).callee === 'Effect.fail',
+    ).length;
+    expect(failCount).toBe(0);
+  });
+
+  it('should generate Mermaid diagram without fail on success path', async () => {
+    const ir = programsByName.get('earlyReturnFail');
+    expect(ir).toBeDefined();
+
+    const mermaid = await Effect.runPromise(renderMermaid(ir!));
+
+    // The diagram should contain the decision node
+    expect(mermaid).toContain('balance < amount');
+
+    // The "no" path (success) should NOT go through a fail node
+    const lines = mermaid.split('\n');
+    const noEdges = lines.filter(l => l.includes('|no|'));
+    for (const edge of noEdges) {
+      expect(edge).not.toMatch(/fail/i);
+    }
+
+    // The fail node should only be reachable from the "yes" (error) path
+    const yesEdges = lines.filter(l => l.includes('|yes|'));
+    expect(yesEdges.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/effect-analyzer/src/__fixtures__/early-return-fail.ts
+++ b/packages/effect-analyzer/src/__fixtures__/early-return-fail.ts
@@ -1,0 +1,28 @@
+/**
+ * Test fixture: Early return with Effect.fail in if-block,
+ * followed by success continuation.
+ *
+ * Bug: The success path (after the if-block) should be a sequential
+ * sibling after the decision node, NOT placed inside onFalse.
+ */
+
+import { Effect } from 'effect';
+
+class InsufficientFundsError {
+  readonly _tag = 'InsufficientFundsError';
+  constructor(readonly message: string) {}
+}
+
+// Pattern: if (condition) { return yield* Effect.fail(...) }
+// followed by success continuation
+export const earlyReturnFail = Effect.gen(function* () {
+  const balance = yield* Effect.succeed(100);
+  const amount = yield* Effect.succeed(50);
+
+  if (balance < amount) {
+    return yield* Effect.fail(new InsufficientFundsError('Not enough funds'));
+  }
+
+  const result = yield* Effect.succeed('converted!');
+  return result;
+});

--- a/packages/effect-analyzer/src/core-analysis.ts
+++ b/packages/effect-analyzer/src/core-analysis.ts
@@ -447,6 +447,21 @@ function isFunctionBoundary(node: Node): boolean {
 }
 
 /**
+ * Check if a call expression is the DIRECT expression of a yield* statement.
+ * Returns true only when the call's immediate parent is a YieldExpression,
+ * meaning the statement walker already fully handles this call as a yielded effect.
+ *
+ * This does NOT filter sub-expressions (e.g., Effect.fn("name") inside
+ * yield* Effect.fn("name")(fn)) — those are legitimately picked up by
+ * the non-yielded scanner.
+ */
+function isDirectYieldExpression(call: Node): boolean {
+  const { SyntaxKind } = loadTsMorph();
+  const parent = call.getParent();
+  return parent !== undefined && parent.getKind() === SyntaxKind.YieldExpression;
+}
+
+/**
  * Boundary-aware check: does `node` contain (or is itself) a YieldExpression
  * without crossing into nested function/class bodies?
  */
@@ -1773,11 +1788,23 @@ export const analyzeGeneratorFunction = (
     // This intentionally includes calls nested inside yield* arguments — the existing
     // behavior produces additional entries for sub-expressions like Effect.provide()
     // inside pipe chains, which tests and downstream consumers rely on.
+    //
+    // However, we must skip calls that are the DIRECT argument of a yield*
+    // expression (these are already fully handled by the statement-level walker).
+    // Without this filter, Effect.fail/succeed calls inside generator yield*
+    // statements get duplicated as flat sibling nodes, causing incorrect diagrams
+    // (e.g., fail nodes appearing on the success path after a conditional branch).
     const calls = body.getDescendantsOfKind(SyntaxKind.CallExpression);
     for (const call of calls) {
       // Skip Effect.withSpan calls — they are merged as annotations on pipe nodes
       const callCallee = call.getExpression().getText();
       if (callCallee.includes('withSpan')) continue;
+
+      // Skip calls that are the direct expression of a yield* — already
+      // handled by the statement-level walker. Only skip the top-level call
+      // (e.g. yield* Effect.succeed(x)), not sub-expressions within it
+      // (e.g. Effect.fn("name") inside yield* Effect.fn("name")(fn)).
+      if (isDirectYieldExpression(call)) continue;
 
       const aliases = getAliasesForFile(sourceFile);
       if (isEffectLikeCallExpression(call, sourceFile, aliases, opts.knownEffectInternalsRoot)) {

--- a/packages/effect-analyzer/src/kitchen-sink-regression.test.ts
+++ b/packages/effect-analyzer/src/kitchen-sink-regression.test.ts
@@ -96,10 +96,8 @@ describe('kitchen-sink regression (improve.md P0)', () => {
     expect(genWithServices).toBeDefined();
     if (genWithServices) {
       const mermaid = await Effect.runPromise(renderMermaid(genWithServices, { direction: 'TB' }));
-      expect(
-        mermaid.includes('string, never, never') ||
-          mermaid.includes('&lt;string, never, never&gt;'),
-      ).toBe(true);
+      // Type signatures are omitted when displayName is present (avoids duplication)
+      // Semantic role annotation should still be present
       expect(mermaid).toContain('(side-effect)');
     }
   });

--- a/packages/effect-analyzer/src/output/mermaid.test.ts
+++ b/packages/effect-analyzer/src/output/mermaid.test.ts
@@ -9,7 +9,7 @@ import {
   summarizePathSteps,
   renderEnhancedMermaid,
 } from './mermaid';
-import type { StaticEffectIR, StaticEffectNode, StaticGeneratorNode } from '../types';
+import type { StaticEffectIR, StaticEffectNode, StaticGeneratorNode, StaticDecisionNode, StaticFlowNode } from '../types';
 
 function makeEffectNode(id: string, callee: string): StaticEffectNode {
   return {
@@ -82,6 +82,28 @@ describe('mermaid', () => {
       ]);
       const diagram = renderStaticMermaid(ir);
       expect(diagram).toContain('testProgram');
+    });
+
+    it('only emits classDef for styles actually used by nodes', () => {
+      const ir = makeIR([
+        makeEffectNode('e1', 'Effect.succeed'),
+      ]);
+      const diagram = renderStaticMermaid(ir);
+      // Start and end styles should always be emitted
+      expect(diagram).toContain('classDef startStyle');
+      expect(diagram).toContain('classDef endStyle');
+      // effectStyle should be emitted since we have an effect node
+      expect(diagram).toContain('classDef effectStyle');
+      // Styles for node types NOT present should NOT be emitted
+      expect(diagram).not.toContain('classDef parallelStyle');
+      expect(diagram).not.toContain('classDef raceStyle');
+      expect(diagram).not.toContain('classDef retryStyle');
+      expect(diagram).not.toContain('classDef timeoutStyle');
+      expect(diagram).not.toContain('classDef resourceStyle');
+      expect(diagram).not.toContain('classDef layerStyle');
+      expect(diagram).not.toContain('classDef streamStyle');
+      expect(diagram).not.toContain('classDef channelStyle');
+      expect(diagram).not.toContain('classDef sinkStyle');
     });
 
     it('respects direction option', () => {
@@ -186,6 +208,76 @@ describe('mermaid', () => {
   });
 
   describe('renderEnhancedMermaid', () => {
+    it('does not duplicate type signature when displayName is present', () => {
+      const effectWithType = makeEffectNode('e1', 'deps.validateTransfer');
+      const typed = effectWithType as StaticEffectNode & {
+        typeSignature?: unknown;
+        displayName?: string;
+        semanticRole?: string;
+      };
+      typed.typeSignature = {
+        successType: 'ValidatedTransfer',
+        errorType: 'ValidationError',
+        requirementsType: 'never',
+        isInferred: true,
+        typeConfidence: 'declared',
+      };
+      typed.displayName = 'validated <- deps.validateTransfer';
+      typed.semanticRole = 'side-effect';
+      const ir = makeIR([
+        makeGeneratorNode('gen-1', [{ effect: effectWithType }]),
+      ]);
+      const diagram = renderEnhancedMermaid(ir);
+      // displayName should appear
+      expect(diagram).toContain('validated <- deps.validateTransfer');
+      // semantic role should still be appended
+      expect(diagram).toContain('side-effect');
+      // type signature should NOT appear (it would be a duplicate)
+      const matches = diagram.match(/ValidatedTransfer/g);
+      expect(matches).toBeNull();
+    });
+
+    it('still appends type signature when displayName is NOT present', () => {
+      const effectWithType = makeEffectNode('e1', 'Effect.succeed');
+      (effectWithType as StaticEffectNode & { typeSignature?: unknown }).typeSignature = {
+        successType: 'number',
+        errorType: 'never',
+        requirementsType: 'never',
+        isInferred: true,
+        typeConfidence: 'declared',
+      };
+      const ir = makeIR([
+        makeGeneratorNode('gen-1', [{ effect: effectWithType }]),
+      ]);
+      const diagram = renderEnhancedMermaid(ir);
+      expect(diagram).toContain('number');
+    });
+
+    it('keeps type signature in static Mermaid when displayName is present', () => {
+      const effectWithType = makeEffectNode('e1', 'deps.validateTransfer');
+      const typed = effectWithType as StaticEffectNode & {
+        typeSignature?: unknown;
+        displayName?: string;
+      };
+      typed.typeSignature = {
+        successType: 'ValidatedTransfer',
+        errorType: 'ValidationError',
+        requirementsType: 'never',
+        isInferred: true,
+        typeConfidence: 'declared',
+      };
+      typed.displayName = 'validated <- deps.validateTransfer';
+      const ir = makeIR([
+        makeGeneratorNode('gen-1', [{ effect: effectWithType }]),
+      ]);
+
+      const diagram = renderStaticMermaid(ir);
+
+      expect(diagram).toContain('validated <- deps.validateTransfer');
+      expect(diagram).toContain('ValidatedTransfer');
+      expect(diagram).toContain('ValidationError');
+    });
+
     it('produces diagram with type annotations when effect has typeSignature', () => {
       const effectWithType = makeEffectNode('e1', 'Effect.succeed');
       (effectWithType as StaticEffectNode & { typeSignature?: unknown }).typeSignature = {
@@ -202,6 +294,36 @@ describe('mermaid', () => {
       expect(diagram).toContain('Start');
       expect(diagram).toContain('End');
       expect(diagram).toContain('number');
+    });
+  });
+
+  describe('decision nodes', () => {
+    it('does not create orphan rectangular nodes for decision type', () => {
+      const decision: StaticDecisionNode = {
+        id: 'dec-1',
+        type: 'decision',
+        decisionId: 'dec-1',
+        label: 'Is valid?',
+        condition: 'isValid',
+        source: 'raw-if',
+        onTrue: [makeEffectNode('e1', 'Effect.succeed')],
+        onFalse: [makeEffectNode('e2', 'Effect.fail')],
+      };
+      const ir = makeIR([decision as unknown as StaticFlowNode]);
+      const diagram = renderStaticMermaid(ir);
+
+      // The diamond decision node should exist
+      expect(diagram).toContain('{');
+      expect(diagram).toContain('Is valid?');
+
+      // Count how many node definitions reference "Is valid?" — should be exactly 1 (the diamond)
+      const nodeDefLines = diagram.split('\n').filter(
+        (line) => line.includes('Is valid?') && (line.includes('[') || line.includes('{'))
+      );
+      expect(nodeDefLines).toHaveLength(1);
+      // That single definition should be the diamond shape, not a rectangle
+      expect(nodeDefLines[0]).toContain('{');
+      expect(nodeDefLines[0]).not.toMatch(/\["/);
     });
   });
 });

--- a/packages/effect-analyzer/src/output/mermaid.ts
+++ b/packages/effect-analyzer/src/output/mermaid.ts
@@ -227,6 +227,15 @@ function renderStaticMermaidInternal(
   const styles = { ...DEFAULT_STYLES, ...opts.styles };
   lines.push('');
   lines.push('  %% Styles');
+
+  // Collect which style keys are actually used by nodes in the diagram
+  const usedStyleKeys = new Set<string>(['start', 'end']);
+  for (const [, styleClass] of context.styleClasses) {
+    // styleClass values are like "effectStyle", "decisionStyle" — strip "Style" suffix to get the key
+    const key = styleClass.endsWith('Style') ? styleClass.slice(0, -5) : styleClass;
+    usedStyleKeys.add(key);
+  }
+
   if (styles.start) {
     lines.push(`  classDef startStyle ${styles.start}`);
   }
@@ -234,7 +243,7 @@ function renderStaticMermaidInternal(
     lines.push(`  classDef endStyle ${styles.end}`);
   }
   for (const [key, value] of Object.entries(styles)) {
-    if (value && key !== 'start' && key !== 'end') {
+    if (value && key !== 'start' && key !== 'end' && usedStyleKeys.has(key)) {
       lines.push(`  classDef ${key}Style ${value}`);
     }
   }
@@ -499,13 +508,17 @@ function getNodeLabel(
   }
 
   // Standard/Verbose: use displayName if available
+  let usedDisplayName = false;
   if (opts.detail !== 'compact' && node.displayName) {
     label = node.displayName;
+    usedDisplayName = true;
   }
 
   // Verbose: append type signature and semantic role
+  // Skip inline type signature when annotations already carry one (enhanced renderer)
+  const annotationsHaveTypeSig = annotations?.some((a) => a.startsWith('<') && a.includes(','));
   if (opts.detail === 'verbose') {
-    if (node.type === 'effect' && opts.includeTypeSignatures && node.typeSignature) {
+    if (!annotationsHaveTypeSig && node.type === 'effect' && opts.includeTypeSignatures && node.typeSignature) {
       const sig = node.typeSignature;
       label += `\n<${sig.successType}, ${sig.errorType}, ${sig.requirementsType}>`;
     }
@@ -515,7 +528,13 @@ function getNodeLabel(
   }
 
   if (annotations?.length) {
-    label += '\n' + annotations.join('\n');
+    // When displayName is used, skip type signature annotations to avoid duplication
+    const filteredAnnotations = usedDisplayName
+      ? annotations.filter((a) => !a.startsWith('<') || !a.includes(','))
+      : annotations;
+    if (filteredAnnotations.length) {
+      label += '\n' + filteredAnnotations.join('\n');
+    }
   }
   return label;
 }
@@ -538,7 +557,8 @@ function renderNode(
   const styleClass = getNodeStyleClass(node);
 
   // Skip the "Generator (N yields)" box so the diagram shows the actual yield steps (varName <- callee, types, etc.)
-  if (node.type !== 'generator') {
+  // Skip decision nodes too — the case 'decision' block creates its own diamond-shaped node.
+  if (node.type !== 'generator' && node.type !== 'decision') {
     lines.push(`  ${nodeId}["${escapeLabel(label)}"]`);
     context.styleClasses.set(nodeId, styleClass);
     context.nodeIdMap.set(node.id, nodeId);
@@ -808,6 +828,7 @@ function renderNode(
       const condLabel = node.label || truncate(node.condition, 25);
       lines.push(`  ${decisionId}{"${escapeLabel(condLabel)}"}`);
       context.styleClasses.set(decisionId, 'decisionStyle');
+      context.nodeIdMap.set(node.id, decisionId);
 
       // Render true branch
       const trueResult = renderNodes(node.onTrue, context, lines);

--- a/packages/effect-analyzer/src/quality-fixes.test.ts
+++ b/packages/effect-analyzer/src/quality-fixes.test.ts
@@ -87,7 +87,8 @@ describe('Quality fixes', () => {
 
   describe('Issue 6: Diff should use stable IDs', () => {
     // `stepsAdded` counts unmatched effect steps after fingerprint + container passes.
-    // A middle insert can surface as 2 in the summary depending on match order; keep as regression lock.
+    // After fixing duplicate yield counting (direct yield* calls are no longer re-added
+    // by the non-yielded scanner), the diff correctly detects 1 new step.
     it('produces stable diffs when a step is added', { timeout: 20_000 }, async () => {
       const [before] = await Effect.runPromise(analyzeEffectSource(`
         import { Effect } from "effect";
@@ -107,7 +108,7 @@ describe('Quality fixes', () => {
         });
       `));
       const diff = diffPrograms(before!, after!);
-      expect(diff.summary.stepsAdded).toBe(2);
+      expect(diff.summary.stepsAdded).toBe(1);
       expect(diff.summary.stepsRemoved).toBe(0);
       expect(diff.summary.stepsRenamed).toBe(0);
     });

--- a/packages/effect-analyzer/src/static-analyzer.test.ts
+++ b/packages/effect-analyzer/src/static-analyzer.test.ts
@@ -2211,7 +2211,10 @@ const WithResult = Schema.SerializableWithResult({ id: Schema.Number });
         ),
       );
 
-      expect(result.metadata.stats.totalEffects).toBeGreaterThan(5);
+      // After fixing duplicate effect counting (direct yield* calls are no
+      // longer re-added by the non-yielded scanner), the real count is 3:
+      // Effect.log, Effect.forEach, Effect.log
+      expect(result.metadata.stats.totalEffects).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -2316,7 +2319,7 @@ const WithResult = Schema.SerializableWithResult({ id: Schema.Number });
       expect(serviceMermaid).toContain('buildProfile');
       // After extractFunctionName cleanup, the callee 'unstableLookup.pipe' becomes 'pipe'
       expect(errorMermaid).toContain('errorTopologyProgram');
-      expect(errorMermaid).toContain('TimeoutException');
+      // TimeoutException is in the error types list, not duplicated in node labels
       expect(serviceMermaid).not.toContain('Generator (');
     });
 
@@ -2512,8 +2515,7 @@ const WithResult = Schema.SerializableWithResult({ id: Schema.Number });
       expect(mermaid).toContain('Logger');
       // Semantic role annotation
       expect(mermaid).toContain('(side-effect)');
-      // Type signature
-      expect(mermaid).toContain('void, never, never');
+      // Type signature is omitted when displayName is present (avoids duplication)
     });
 
     it('standard: includes variable names but NOT type sigs or roles', async () => {


### PR DESCRIPTION
Introduced a new test to verify that type signatures are correctly retained in static Mermaid diagrams when a displayName is present. This ensures that the displayName and type information are accurately represented without duplication.