### PR TITLE
feat(effect-analyzer): state machine analysis with XState-style statecharts

### DIFF
--- a/.changeset/state-machine-statecharts.md
+++ b/.changeset/state-machine-statecharts.md
@@ -1,0 +1,9 @@
+---
+"effect-analyzer": minor
+---
+
+Add state machine analysis with XState-style statecharts.
+
+Detect plain-Effect state machines (declarative transition tables and Match.when transition functions) and render them as statecharts without an XState dependency. Renderers cover mermaid (stateDiagram-v2), a self-contained SVG, a local HTML visualizer (with `--open`), and pasteable `createMachine()` config for stately.ai/viz.
+
+Schema-aware coverage reads the declared alphabet from tagged unions or Schema-derived types and reports unhandled events, unreachable states, and undeclared symbols, with a `--min-coverage` threshold, `--coverage-json`, and a non-zero CI exit on warnings. When a command finds no machines, near-miss diagnostics explain why each candidate was rejected.

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -75,6 +75,11 @@ PATH defaults to `.` (current directory). When PATH is a directory, analyzes all
 | `mermaid-retry` | Retry/resilience patterns |
 | `mermaid-testability` | Testing readiness diagram |
 | `mermaid-dataflow` | Variable flow |
+| `mermaid-statechart` | State machine as `stateDiagram-v2` (coverage-annotated) |
+| `svg-statechart` | Self-contained XState-styled statechart SVG (coverage-annotated) |
+| `statechart-html` | Local visualizer page: SVG, coverage, XState export |
+| `xstate-config` | `createMachine()` config for stately.ai/viz |
+| `statechart-coverage` | Completeness report; exits non-zero on warnings (CI gate) |
 | `explain` | Plain-English narrative |
 | `summary` | One-liner |
 | `stats` | Complexity metrics |
@@ -225,6 +230,8 @@ All exported from `src/index.ts`:
 - **DI completeness:** `checkDICompleteness()` — Service satisfaction
 - **Strict diagnostics:** `validateStrict()` — Strict mode validation
 - **Match analysis:** `analyzeMatch()` — Match statement patterns
+- **State machines:** `analyzeStateMachines(filePath)` — extracts FSMs (transition tables + `Match.when` functions + nested `Match.tags` state/event dispatch), declared alphabet from types/Schema/Schema.TaggedClass/Schema.TaggedRequest; `computeStateMachineCoverage()` flags unhandled events / unreachable states / undeclared symbols. Renderers: `renderStatechartMermaid`, `renderStatechartSVG`, `renderStatechartVisualizerHTML`, `renderXStateConfig`, `renderCoverageReport`, `hasCoverageWarnings`. CLI handled by `runStatechartMode` (early dispatch, not the IR pipeline).
+  - Convention guide: `packages/effect-analyzer/state-machine-conventions.md`
 - **Platform:** `analyzePlatformUsage()` — Platform detection
 - **Testing:** `analyzeTestingPatterns()` — Test pattern detection
 - **Version:** `getEffectVersion()`, `checkVersionCompat()`

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ apps/docs/**/.DS_Store
 !apps/docs/src/content/docs/case-studies/transfer-observability.mdx
 ___temp
 apps/docs/.design-screens
+
+# Generated statechart visualizers (effect-analyze --format statechart-html / svg-statechart)
+*.statechart.html
+effect-statecharts.html

--- a/packages/effect-analyzer/README.md
+++ b/packages/effect-analyzer/README.md
@@ -111,8 +111,127 @@ Auto-mode picks the most relevant views for your program, or choose explicitly:
 | `mermaid-layers` | Layer composition graph |
 | `mermaid-retry` | Retry and timeout strategies |
 | `mermaid-timeline` | Step sequence over time |
+| `mermaid-statechart` | State machine as a `stateDiagram-v2` |
+| `svg-statechart` | Self-contained, XState-styled statechart SVG |
+| `statechart-html` | Local visualizer page with SVG, coverage, and XState export |
+| `xstate-config` | `createMachine()` config for the [Stately visualizer](https://stately.ai/viz) |
 
 [See all formats →](https://jagreehal.github.io/effect-analyzer/diagrams/all-formats/)
+
+### State Machines Without XState
+
+Write deterministic state machines in plain Effect — a declarative transition
+table, a `Match.when` transition function, or nested `Match.tags` state/event
+dispatch — and render them as XState-style statecharts. No XState dependency
+required. See the full convention guide in
+[`state-machine-conventions.md`](./state-machine-conventions.md).
+
+```bash
+# No flags: the default view surfaces any state machine in the file
+npx effect-analyze ./workflow.ts
+
+# A local visualizer page (diagram + coverage + paste-ready config).
+# With no -o it writes workflow.statechart.html next to the input
+npx effect-analyze ./workflow.ts --format statechart-html
+
+# A stateDiagram-v2 for markdown / GitHub
+npx effect-analyze ./workflow.ts --format mermaid-statechart
+
+# An XState createMachine() config — paste into stately.ai/viz for the real
+# interactive visualizer, generated straight from your Effect code
+npx effect-analyze ./workflow.ts --format xstate-config
+```
+
+These shapes are recognized:
+
+```ts
+// A) declarative transition table
+const transitions = {
+  Triage: {
+    RefundRequested: { target: 'Refund', guard: 'canRefund' },
+    AnswerRequested: 'Answered',
+  },
+  Refund: { Resolved: 'Answered' },
+  Answered: {},
+} as const;
+
+// B) Match.when transition function
+const transition = (state: State, event: Event): State =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['Draft', 'Submit'], () => ({ _tag: 'Review' as const })),
+    Match.orElse(() => state),
+  );
+
+// C) nested Match.tags with state tags outside and event tags inside
+const transitionWithTags = (state: State, event: Event): State =>
+  Match.value(state).pipe(
+    Match.tags({
+      Draft: () =>
+        Match.value(event).pipe(
+          Match.tags({
+            Submit: () => ({ _tag: 'Review' as const }),
+          }),
+        ),
+      Review: () => state,
+    }),
+  );
+```
+
+Initial state is read from an `@initial <State>` annotation or an
+`initial`/`initialState` declaration. Table leaves can be strings,
+`{ target, guard }`, `{ to }`, or arrays of guarded targets. A handler that can
+return more than one state becomes a guarded (multi-target) transition.
+
+#### Completeness checking (Schema-aware)
+
+When the State/Event types are a tagged union or a `Schema`-derived type, the
+analyzer reads the **declared alphabet** and checks the machine against it —
+turning the statechart from a drawing into a verified machine:
+
+```bash
+npx effect-analyze ./workflow.ts --format statechart-coverage
+```
+
+```
+# State machine coverage
+
+1 machine, 2 warnings.
+
+## checkoutTransition (alphabet: schema)
+Coverage: 33% (2/6 reachable state×event pairs handled)
+- ⚠ Unhandled events: `Cancel`        # declared, but no state handles it
+- ⚠ Unreachable states: `Cancelled`   # declared, but nothing transitions to it
+```
+
+It reports **unhandled events**, **unreachable states**, and **undeclared
+symbols** (transitions that drifted from the types). The command **exits
+non-zero when any warning is found**, so it works as a CI gate. The
+`mermaid-statechart` and `svg-statechart` outputs are annotated with the same
+findings (orphaned states highlighted, unhandled events noted).
+
+Run it over a whole directory for a summary table, set a coverage floor, or emit
+JSON for dashboards:
+
+```bash
+npx effect-analyze ./src --format statechart-coverage              # all machines, summary table
+npx effect-analyze ./src --format statechart-coverage --min-coverage 60   # fail under 60%
+npx effect-analyze ./src --format statechart-coverage --coverage-json     # { machines, summary }
+```
+
+Guarded (conditional) transitions are captured with their condition and shown
+on every renderer (`Event [guard]` in diagrams, `{ target, guard }` in the
+XState config). State/Event alphabets may be tagged unions, `Schema`-derived
+types, `Schema.TaggedClass`/`Schema.TaggedRequest` unions, or plain
+string-literal unions (`'a' | 'b'`).
+
+Plain single-level `Match.tags` dispatch is intentionally ignored unless there
+is a nested state/event shape, because ordinary variant handling does not have
+the source-state dimension required for a statechart.
+
+> **Not yet supported:** hierarchical (nested) and parallel states. There is no
+> standard Effect encoding for them, so detection is deferred until a convention
+> is settled (dotted tags like `'Active.Running'` are the likely path and render
+> safely as flat states today).
 
 ### Complexity Metrics
 

--- a/packages/effect-analyzer/package.json
+++ b/packages/effect-analyzer/package.json
@@ -32,7 +32,8 @@
   "files": [
     "dist",
     "scripts",
-    "README.md"
+    "README.md",
+    "state-machine-conventions.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/effect-analyzer/src/__fixtures__/state-machine-advanced.ts
+++ b/packages/effect-analyzer/src/__fixtures__/state-machine-advanced.ts
@@ -1,0 +1,56 @@
+/**
+ * Advanced state-machine fixtures exercising the hardened detection paths:
+ *  - block-body Match.when handlers (return statements)
+ *  - a guarded handler with multiple returned tags (one edge per target)
+ *  - an explicit `initial` declaration
+ *  - an `@initial` annotation on a transition table
+ */
+
+import { Match } from 'effect';
+
+// ---------------------------------------------------------------------------
+// Block-body handlers + guarded (multi-target) transition + initial const
+// ---------------------------------------------------------------------------
+
+type JobState =
+  | { readonly _tag: 'Queued' }
+  | { readonly _tag: 'Running' }
+  | { readonly _tag: 'Done' }
+  | { readonly _tag: 'Failed' };
+
+type JobEvent =
+  | { readonly _tag: 'Start' }
+  | { readonly _tag: 'Finish' }
+  | { readonly _tag: 'Error' };
+
+// Picked up as the initial state for the machine that contains "Queued".
+const initialState: JobState = { _tag: 'Queued' };
+void initialState;
+
+export const jobTransition = (state: JobState, event: JobEvent): JobState =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['Queued', 'Start'], () => {
+      return { _tag: 'Running' as const };
+    }),
+    Match.when(['Running', 'Finish'], () => {
+      // guarded: success goes to Done, otherwise Failed
+      if (Math.random() > 0.5) {
+        return { _tag: 'Done' as const };
+      }
+      return { _tag: 'Failed' as const };
+    }),
+    Match.when(['Running', 'Error'], () => {
+      return { _tag: 'Failed' as const };
+    }),
+    Match.orElse(() => state),
+  );
+
+// ---------------------------------------------------------------------------
+// Transition table with an annotation overriding the first-key default
+// ---------------------------------------------------------------------------
+
+/** @initial Open */
+export const gateTransitions = {
+  Closed: { Unlock: 'Open' },
+  Open: { Lock: 'Closed' },
+} as const;

--- a/packages/effect-analyzer/src/__fixtures__/state-machine-effect-idioms.ts
+++ b/packages/effect-analyzer/src/__fixtures__/state-machine-effect-idioms.ts
@@ -1,0 +1,76 @@
+import { Match, Schema } from 'effect';
+
+class Idle extends Schema.TaggedClass<Idle>()('Idle', {}) {}
+class Active extends Schema.TaggedClass<Active>()('Active', {}) {}
+class Closed extends Schema.TaggedClass<Closed>()('Closed', {}) {}
+
+class Start extends Schema.TaggedRequest<Start>()('Start', {
+  failure: Schema.Never,
+  success: Schema.Void,
+  payload: {},
+}) {}
+class Stop extends Schema.TaggedRequest<Stop>()('Stop', {
+  failure: Schema.Never,
+  success: Schema.Void,
+  payload: {},
+}) {}
+class Fail extends Schema.TaggedRequest<Fail>()('Fail', {
+  failure: Schema.Never,
+  success: Schema.Void,
+  payload: {},
+}) {}
+
+type WorkflowState = Idle | Active | Closed;
+type WorkflowEvent = Start | Stop | Fail;
+type WorkflowTarget =
+  | WorkflowState['_tag']
+  | { readonly target: WorkflowState['_tag']; readonly guard?: string }
+  | { readonly to: WorkflowState['_tag'] }
+  | readonly { readonly target: WorkflowState['_tag']; readonly guard?: string }[];
+
+/** @initial Idle */
+export const workflowTransitions = {
+  Idle: {
+    Start: { target: 'Active', guard: 'canStart' },
+  },
+  Active: {
+    Stop: { to: 'Closed' },
+    Fail: [{ target: 'Closed', guard: 'isFatal' }, { target: 'Idle' }],
+  },
+  Closed: {},
+} as const satisfies Record<
+  WorkflowState['_tag'],
+  Partial<Record<WorkflowEvent['_tag'], WorkflowTarget>>
+>;
+
+export const taggedTransition = (
+  state: WorkflowState,
+  event: WorkflowEvent,
+): WorkflowState =>
+  Match.value(state).pipe(
+    Match.tags({
+      Idle: () =>
+        Match.value(event).pipe(
+          Match.tags({
+            Start: () => ({ _tag: 'Active' as const }),
+          }),
+        ),
+      Active: () =>
+        Match.value(event).pipe(
+          Match.tags({
+            Stop: () => ({ _tag: 'Closed' as const }),
+            Fail: () => ({ _tag: 'Idle' as const }),
+          }),
+        ),
+      Closed: () => state,
+    }),
+  );
+
+export const plainVariantDispatch = (event: WorkflowEvent): string =>
+  Match.value(event).pipe(
+    Match.tags({
+      Start: () => 'started',
+      Stop: () => 'stopped',
+      Fail: () => 'failed',
+    }),
+  );

--- a/packages/effect-analyzer/src/__fixtures__/state-machine-literal.ts
+++ b/packages/effect-analyzer/src/__fixtures__/state-machine-literal.ts
@@ -1,0 +1,18 @@
+/**
+ * Literal / intent-style state machine: State and Event are string-literal
+ * unions (no `_tag`), and handlers return the next state as a bare string.
+ * Exercises string-union alphabet extraction and string-literal handler returns.
+ */
+
+import { Match } from 'effect';
+
+type Light = 'Red' | 'Yellow' | 'Green';
+type Signal = 'Tick';
+
+export const lightTransition = (state: Light, signal: Signal): Light =>
+  Match.value([state, signal] as const).pipe(
+    Match.when(['Red', 'Tick'], () => 'Green' as const),
+    Match.when(['Green', 'Tick'], () => 'Yellow' as const),
+    Match.when(['Yellow', 'Tick'], () => 'Red' as const),
+    Match.orElse(() => state),
+  );

--- a/packages/effect-analyzer/src/__fixtures__/state-machine-near-miss.ts
+++ b/packages/effect-analyzer/src/__fixtures__/state-machine-near-miss.ts
@@ -1,0 +1,35 @@
+/**
+ * Declarations that look like state machines but are not recognized, used to
+ * test the near-miss diagnostics. None of these should produce a machine.
+ */
+
+import { Match } from 'effect';
+
+// Table-shaped, but no event leads to another state — reads as config.
+export const settingsTransitions = {
+  audio: { volume: 'high' },
+  video: { quality: 'hd' },
+} as const;
+
+type S = { readonly _tag: 'A' } | { readonly _tag: 'B' };
+type E = { readonly _tag: 'Go' };
+
+function makeNext(): S {
+  return { _tag: 'B' };
+}
+
+// Match.when with a 2-tuple, but the handler returns a computed (non-literal) state.
+export const computedTransition = (state: S, event: E): S =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['A', 'Go'], () => makeNext()),
+    Match.orElse(() => state),
+  );
+
+// Single-level Match.tags — variant dispatch, not a transition.
+export const describe = (state: S): string =>
+  Match.value(state).pipe(
+    Match.tags({
+      A: () => 'is A',
+      B: () => 'is B',
+    }),
+  );

--- a/packages/effect-analyzer/src/__fixtures__/state-machine-schema.ts
+++ b/packages/effect-analyzer/src/__fixtures__/state-machine-schema.ts
@@ -1,0 +1,35 @@
+/**
+ * Schema-based state-machine fixture.
+ *
+ * The State/Event alphabets are declared with `effect/Schema` and the machine
+ * is deliberately INCOMPLETE so coverage analysis has something to report:
+ *  - `Cancel` is a declared event that no state handles  → unhandled event
+ *  - `Cancelled` is a declared state nothing transitions to → unreachable state
+ */
+
+import { Match, Schema } from 'effect';
+
+const CheckoutState = Schema.Union(
+  Schema.TaggedStruct('Cart', {}),
+  Schema.TaggedStruct('Payment', {}),
+  Schema.TaggedStruct('Confirmed', {}),
+  Schema.TaggedStruct('Cancelled', {}),
+);
+type CheckoutState = Schema.Schema.Type<typeof CheckoutState>;
+
+const CheckoutEvent = Schema.Union(
+  Schema.TaggedStruct('Checkout', {}),
+  Schema.TaggedStruct('Pay', {}),
+  Schema.TaggedStruct('Cancel', {}),
+);
+type CheckoutEvent = Schema.Schema.Type<typeof CheckoutEvent>;
+
+export const checkoutTransition = (
+  state: CheckoutState,
+  event: CheckoutEvent,
+): CheckoutState =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['Cart', 'Checkout'], () => ({ _tag: 'Payment' as const })),
+    Match.when(['Payment', 'Pay'], () => ({ _tag: 'Confirmed' as const })),
+    Match.orElse(() => state),
+  );

--- a/packages/effect-analyzer/src/__fixtures__/state-machine.ts
+++ b/packages/effect-analyzer/src/__fixtures__/state-machine.ts
@@ -1,0 +1,65 @@
+/**
+ * State machine fixtures — plain Effect, no XState.
+ *
+ * Two shapes the analyzer should recognize:
+ *  A) a declarative transition table (object literal)
+ *  B) a Match.value([state, event]).pipe(Match.when([from, event], () => toState)) function
+ */
+
+import { Match } from 'effect';
+
+// ---------------------------------------------------------------------------
+// Shape A: declarative transition table
+// ---------------------------------------------------------------------------
+
+type SupportState =
+  | { readonly _tag: 'Triage' }
+  | { readonly _tag: 'Refund' }
+  | { readonly _tag: 'Human' }
+  | { readonly _tag: 'Answered' };
+
+type SupportEvent =
+  | { readonly _tag: 'RefundRequested' }
+  | { readonly _tag: 'EscalationRequested' }
+  | { readonly _tag: 'AnswerRequested' }
+  | { readonly _tag: 'Resolved' };
+
+export const supportTransitions = {
+  Triage: {
+    RefundRequested: 'Refund',
+    EscalationRequested: 'Human',
+    AnswerRequested: 'Answered',
+  },
+  Refund: {
+    Resolved: 'Answered',
+  },
+  Human: {
+    Resolved: 'Answered',
+  },
+  Answered: {},
+} as const satisfies Record<
+  SupportState['_tag'],
+  Partial<Record<SupportEvent['_tag'], SupportState['_tag']>>
+>;
+
+// ---------------------------------------------------------------------------
+// Shape B: Match.when tuple transition function
+// ---------------------------------------------------------------------------
+
+type DocState =
+  | { readonly _tag: 'Draft' }
+  | { readonly _tag: 'Review' }
+  | { readonly _tag: 'Published' };
+
+type DocEvent =
+  | { readonly _tag: 'Submit' }
+  | { readonly _tag: 'Approve' }
+  | { readonly _tag: 'Reject' };
+
+export const docTransition = (state: DocState, event: DocEvent): DocState =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['Draft', 'Submit'], () => ({ _tag: 'Review' as const })),
+    Match.when(['Review', 'Approve'], () => ({ _tag: 'Published' as const })),
+    Match.when(['Review', 'Reject'], () => ({ _tag: 'Draft' as const })),
+    Match.orElse(() => state),
+  );

--- a/packages/effect-analyzer/src/cli.ts
+++ b/packages/effect-analyzer/src/cli.ts
@@ -3,7 +3,7 @@
  */
 
 import './register-node-ts-morph';
-import { resolve, sep, join, dirname, extname, isAbsolute } from 'path';
+import { resolve, sep, join, dirname, extname, isAbsolute, basename } from 'path';
 import { watch, existsSync } from 'fs';
 import * as fs from 'node:fs/promises';
 import { Project } from 'ts-morph';
@@ -34,6 +34,20 @@ import { renderLayersMermaid } from './output/mermaid-layers';
 import { renderRetryMermaid } from './output/mermaid-retry';
 import { renderTestabilityMermaid } from './output/mermaid-testability';
 import { renderDataflowMermaid } from './output/mermaid-dataflow';
+import { analyzeStateMachines, type StateMachine } from './state-machine';
+import { diagnoseStateMachines } from './state-machine-diagnostics';
+import {
+  computeStateMachineCoverage,
+  type StateMachineCoverage,
+} from './state-machine-coverage';
+import { renderStatechartsMermaid } from './output/mermaid-statechart';
+import { renderStatechartSVG, renderStatechartHTML } from './output/svg-statechart';
+import { renderStatechartVisualizerHTML } from './output/statechart-html';
+import { renderXStateConfig } from './output/xstate-config';
+import {
+  renderCoverageReport,
+  summarizeCoverage,
+} from './output/statechart-coverage';
 import { selectFormats } from './output/auto-format';
 import { diffPrograms, renderDiffMarkdown, renderDiffJSON, renderDiffMermaid, parseSourceArg, resolveGitSource, resolveGitHubPR } from './diff';
 import { generatePaths } from './path-generator';
@@ -153,7 +167,7 @@ const resolveCliPath = (inputPath: string | undefined): string => {
 };
 
 interface CLIOptions {
-  readonly format: 'auto' | 'json' | 'mermaid' | 'mermaid-paths' | 'mermaid-enhanced' | 'mermaid-railway' | 'mermaid-services' | 'mermaid-errors' | 'mermaid-decisions' | 'mermaid-causes' | 'mermaid-concurrency' | 'mermaid-timeline' | 'mermaid-layers' | 'mermaid-retry' | 'mermaid-testability' | 'mermaid-dataflow' | 'stats' | 'migration' | 'showcase' | 'explain' | 'summary' | 'matrix' | 'architecture' | 'api-docs' | 'openapi-paths' | 'openapi-runtime';
+  readonly format: 'auto' | 'json' | 'mermaid' | 'mermaid-paths' | 'mermaid-enhanced' | 'mermaid-railway' | 'mermaid-services' | 'mermaid-errors' | 'mermaid-decisions' | 'mermaid-causes' | 'mermaid-concurrency' | 'mermaid-timeline' | 'mermaid-layers' | 'mermaid-retry' | 'mermaid-testability' | 'mermaid-dataflow' | 'mermaid-statechart' | 'svg-statechart' | 'statechart-html' | 'xstate-config' | 'statechart-coverage' | 'stats' | 'migration' | 'showcase' | 'explain' | 'summary' | 'matrix' | 'architecture' | 'api-docs' | 'openapi-paths' | 'openapi-runtime';
   readonly openapiExport: string | undefined;
   readonly output: string | undefined;
   readonly pretty: boolean;
@@ -176,6 +190,9 @@ interface CLIOptions {
   readonly jsonSummary: boolean;
   readonly perFileTiming: boolean;
   readonly minMeaningfulNodes: number | undefined;
+  readonly minCoverage: number | undefined;
+  readonly coverageJson: boolean;
+  readonly open: boolean;
   readonly excludeFromSuspiciousZeros: string[];
   readonly knownEffectInternalsRoot: string | undefined;
   readonly quiet: boolean;
@@ -275,6 +292,9 @@ function parseArgs(args: readonly string[]): { pathArg: string | undefined; opti
   let jsonSummary = false;
   let perFileTiming = false;
   let minMeaningfulNodes: number | undefined;
+  let minCoverage: number | undefined;
+  let coverageJson = false;
+  let open = false;
   const excludeFromSuspiciousZeros: string[] = [];
   let knownEffectInternalsRoot: string | undefined;
   let quiet = false;
@@ -361,6 +381,11 @@ function parseArgs(args: readonly string[]): { pathArg: string | undefined; opti
         value === 'mermaid-retry' ||
         value === 'mermaid-testability' ||
         value === 'mermaid-dataflow' ||
+        value === 'mermaid-statechart' ||
+        value === 'svg-statechart' ||
+        value === 'statechart-html' ||
+        value === 'xstate-config' ||
+        value === 'statechart-coverage' ||
         value === 'stats' ||
         value === 'migration' ||
         value === 'showcase' ||
@@ -448,6 +473,18 @@ function parseArgs(args: readonly string[]): { pathArg: string | undefined; opti
           minMeaningfulNodes = parsed;
         }
       }
+    } else if (arg === '--min-coverage') {
+      const value = args[++i];
+      if (value !== undefined) {
+        const parsed = Number.parseFloat(value);
+        if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 100) {
+          minCoverage = parsed;
+        }
+      }
+    } else if (arg === '--coverage-json') {
+      coverageJson = true;
+    } else if (arg === '--open') {
+      open = true;
     } else if (arg === '--exclude-from-suspicious-zero') {
       const value = args[++i];
       if (value !== undefined) excludeFromSuspiciousZeros.push(value);
@@ -669,6 +706,9 @@ function parseArgs(args: readonly string[]): { pathArg: string | undefined; opti
     jsonSummary,
     perFileTiming,
     minMeaningfulNodes,
+    minCoverage,
+    coverageJson,
+    open,
     excludeFromSuspiciousZeros,
     knownEffectInternalsRoot,
     quiet,
@@ -735,7 +775,7 @@ Usage: effect-analyze [PATH] [options]
   verbose output, enhanced Mermaid, colors). Use --no-colocate to skip writing files.
 
 Options:
-  -f, --format <format>    Output format: auto | json | mermaid | mermaid-paths | mermaid-enhanced | mermaid-railway | mermaid-services | mermaid-errors | mermaid-decisions | mermaid-causes | mermaid-concurrency | mermaid-timeline | mermaid-layers | mermaid-retry | mermaid-testability | mermaid-dataflow | stats | showcase | explain | summary | matrix | architecture | api-docs | openapi-paths | openapi-runtime (default: auto)
+  -f, --format <format>    Output format: auto | json | mermaid | mermaid-paths | mermaid-enhanced | mermaid-railway | mermaid-services | mermaid-errors | mermaid-decisions | mermaid-causes | mermaid-concurrency | mermaid-timeline | mermaid-layers | mermaid-retry | mermaid-testability | mermaid-dataflow | mermaid-statechart | svg-statechart | statechart-html | xstate-config | statechart-coverage | stats | showcase | explain | summary | matrix | architecture | api-docs | openapi-paths | openapi-runtime (default: auto)
   --export <name>          For openapi-runtime: export name of HttpApi (default: first/default)
   -o, --output <file>      Output file (default: stdout)
   -d, --direction <dir>    Mermaid diagram direction: TB | LR | BT | RL (default: TB)
@@ -762,6 +802,9 @@ Options:
   --show-by-folder         With --coverage-audit: show ok/zero/fail counts by top-level folder
   --per-file-timing        With --coverage-audit: include per-file durationMs in audit (optional timing)
   --min-meaningful-nodes <n>  Filter analyzed programs with fewer than n non-unknown nodes (public-output mode)
+  --min-coverage <n>       With --format statechart-coverage: fail (exit 1) if any machine is below n%% coverage
+  --coverage-json          With --format statechart-coverage: emit JSON ({ machines, summary }) for dashboards
+  --open                   With --format statechart-html/svg-statechart: open the written HTML in your browser
   --exclude-from-suspicious-zero <pattern>  With --coverage-audit: exclude paths matching pattern from suspicious zeros (repeatable)
   --known-effect-internals-root <path>      With --coverage-audit: treat local imports under path as Effect (improve.md §1)
   --json-summary           With --coverage-audit: print only audit JSON to stdout (CI mode)
@@ -824,6 +867,11 @@ Examples:
   effect-analyze ./src --lint-source --scorecard
   effect-analyze ./src --service-cycles --format json
   effect-analyze ./src --lint-source --bundle-output ./.artifacts/effect-lint
+  effect-analyze ./workflow.ts --format mermaid-statechart   # State machine → mermaid stateDiagram-v2
+  effect-analyze ./workflow.ts --format svg-statechart -o sc.html  # Self-contained XState-styled SVG
+  effect-analyze ./workflow.ts --format statechart-html -o sc.html  # Local visualizer page
+  effect-analyze ./workflow.ts --format xstate-config   # Emit createMachine() config for stately.ai/viz
+  effect-analyze ./workflow.ts --format statechart-coverage   # Completeness report (exit 1 on warnings — CI gate)
   effect-analyze ./src --format api-docs   # Extract HttpApi structure, emit API docs markdown
   effect-analyze ./src --format openapi-paths -o paths.json  # Emit OpenAPI paths JSON
   effect-analyze ./src/api.ts --format openapi-runtime --export TodoApi -o openapi.json  # Runtime OpenApi.fromApi
@@ -1913,6 +1961,169 @@ const runApiDocsMode = (
     }
   });
 
+/** Best-effort open of a file in the OS default application. */
+const openInBrowser = (file: string): Effect.Effect<void> =>
+  Effect.sync(() => {
+    let cmd: string;
+    let args: string[];
+    if (process.platform === 'darwin') {
+      cmd = 'open';
+      args = [file];
+    } else if (process.platform === 'win32') {
+      cmd = 'cmd';
+      args = ['/c', 'start', '', file];
+    } else {
+      cmd = 'xdg-open';
+      args = [file];
+    }
+    try {
+      spawn(cmd, args, { stdio: 'ignore', detached: true }).unref();
+    } catch {
+      // best-effort; a failed open should not fail the command
+    }
+  });
+
+/**
+ * Run a statechart format (mermaid-statechart | svg-statechart | statechart-html | xstate-config).
+ * These analyze plain-Effect state machines directly from source (transition
+ * tables and Match.when transition functions) — no Effect IR required.
+ */
+const runStatechartMode = (
+  resolvedPath: string,
+  options: CLIOptions,
+): Effect.Effect<void, unknown> =>
+  Effect.gen(function* () {
+    let files: string[];
+    const stat = yield* Effect.tryPromise(() => fs.stat(resolvedPath)).pipe(
+      Effect.option,
+    );
+    if (Option.isSome(stat) && stat.value.isDirectory()) {
+      const exts = ['.ts', '.tsx'];
+      const walk = async (dir: string, depth: number): Promise<string[]> => {
+        if (depth > 10) return [];
+        const result: string[] = [];
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        for (const e of entries) {
+          const full = join(dir, e.name);
+          if (e.isDirectory() && e.name !== 'node_modules' && e.name !== '.git') {
+            result.push(...(await walk(full, depth + 1)));
+          } else if (e.isFile() && exts.includes(extname(e.name))) {
+            result.push(full);
+          }
+        }
+        return result;
+      };
+      files = yield* Effect.tryPromise(() => walk(resolvedPath, 0));
+    } else {
+      files = [resolvedPath];
+    }
+
+    const machines: StateMachine[] = [];
+    for (const file of files) {
+      try {
+        machines.push(...analyzeStateMachines(file).machines);
+      } catch {
+        // skip parse errors
+      }
+    }
+
+    if (machines.length === 0) {
+      const rejections = files.flatMap((file) => {
+        try {
+          return [...diagnoseStateMachines(file).rejected];
+        } catch {
+          return [];
+        }
+      });
+      if (rejections.length === 0) {
+        yield* Console.error(
+          'No state machines found. See docs/effect-state-machine-conventions.md for the transition-table and Match.when shapes.',
+        );
+      } else {
+        yield* Console.error(
+          `No state machines found, but ${rejections.length} declaration${rejections.length === 1 ? '' : 's'} came close:`,
+        );
+        for (const r of rejections) {
+          const loc = r.location
+            ? ` ${basename(r.location.filePath)}:${r.location.line}`
+            : '';
+          yield* Console.error(`  • ${r.name} (${r.kind})${loc}`);
+          yield* Console.error(`      ${r.reason}`);
+          yield* Console.error(`      fix: ${r.hint}`);
+        }
+      }
+      return;
+    }
+
+    const coverages: StateMachineCoverage[] = machines.map(
+      computeStateMachineCoverage,
+    );
+
+    // Summary header to stderr so stdout (config/diagram) stays pipe-clean.
+    if (!options.quiet) {
+      yield* Console.error(
+        `Found ${machines.length} state machine${machines.length === 1 ? '' : 's'}:`,
+      );
+      for (const m of machines) {
+        const stateCount = m.states.length;
+        const eventCount = new Set(m.transitions.map((t) => t.event)).size;
+        yield* Console.error(
+          `  • ${m.name}: ${stateCount} state${stateCount === 1 ? '' : 's'}, ${eventCount} event${eventCount === 1 ? '' : 's'}` +
+            (m.alphabetSource ? ` (${m.alphabetSource})` : ''),
+        );
+      }
+    }
+
+    let output: string;
+    if (options.format === 'xstate-config') {
+      output = machines.map(renderXStateConfig).join('\n\n');
+    } else if (options.format === 'statechart-html') {
+      output = renderStatechartVisualizerHTML(machines, coverages);
+    } else if (options.format === 'svg-statechart') {
+      output = renderStatechartHTML(
+        machines.map((m, i) => renderStatechartSVG(m, coverages[i])),
+      );
+    } else if (options.format === 'statechart-coverage') {
+      const summary = summarizeCoverage(coverages, options.minCoverage);
+      output = options.coverageJson
+        ? JSON.stringify({ machines: coverages, summary }, null, options.pretty ? 2 : undefined)
+        : renderCoverageReport(coverages, { minCoverage: options.minCoverage });
+      // Non-zero exit for CI on any warning or sub-threshold machine.
+      if (!summary.passed) {
+        yield* Effect.sync(() => {
+          process.exitCode = 1;
+        });
+      }
+    } else {
+      output = renderStatechartsMermaid({ machines }, coverages);
+    }
+
+    // HTML formats are documents, not pipeable text: when no -o is given, write
+    // a file next to the input and print its path rather than dumping markup.
+    const isHtml =
+      options.format === 'statechart-html' ||
+      options.format === 'svg-statechart';
+    const firstFile = files[0];
+    const defaultHtmlPath =
+      files.length === 1 && firstFile
+        ? `${basename(firstFile).replace(/\.[^.]+$/, '')}.statechart.html`
+        : 'effect-statecharts.html';
+    const outputPath = options.output ?? (isHtml ? defaultHtmlPath : undefined);
+
+    if (outputPath) {
+      yield* Effect.tryPromise(() => fs.writeFile(outputPath, output, 'utf-8'));
+      yield* Console.log(
+        isHtml ? `Statechart written to ${outputPath}` : `Output written to ${outputPath}`,
+      );
+      if (options.open && isHtml) {
+        yield* Console.log(`Opening ${outputPath}…`);
+        yield* openInBrowser(outputPath);
+      }
+    } else {
+      yield* Console.log(output);
+    }
+  });
+
 const runMigration = (resolvedPath: string): Effect.Effect<void> =>
   Effect.gen(function* () {
     const s = yield* Effect.tryPromise(() => fs.stat(resolvedPath)).pipe(
@@ -2438,6 +2649,17 @@ const main = Effect.gen(function* () {
     return Exit.succeed(undefined);
   }
 
+  if (
+    options.format === 'mermaid-statechart' ||
+    options.format === 'svg-statechart' ||
+    options.format === 'statechart-html' ||
+    options.format === 'xstate-config' ||
+    options.format === 'statechart-coverage'
+  ) {
+    yield* runStatechartMode(resolvedPath, options);
+    return Exit.succeed(undefined);
+  }
+
   if (options.format === 'openapi-runtime') {
     if (isDir) {
       yield* Console.error('openapi-runtime requires a file path (entrypoint), not a directory.');
@@ -2456,6 +2678,30 @@ const main = Effect.gen(function* () {
     yield* Console.log(`Analyzing ${resolvedPath}...`);
   }
   yield* runAnalysis(resolvedPath, options);
+
+  // Discoverability: in the default (auto) view, surface any state machines in
+  // the file so users find the feature without knowing the --format flag.
+  if (options.format === 'auto' && !options.output && !options.colocate) {
+    const machines = yield* Effect.sync(() => {
+      try {
+        return analyzeStateMachines(resolvedPath).machines;
+      } catch {
+        return [];
+      }
+    });
+    if (machines.length > 0) {
+      const coverages = machines.map(computeStateMachineCoverage);
+      yield* Console.log(
+        `\n%% statechart\n${renderStatechartsMermaid({ machines }, coverages)}`,
+      );
+      if (!options.quiet) {
+        yield* Console.error(
+          `\n${machines.length} state machine${machines.length === 1 ? '' : 's'} detected. ` +
+            `For diagram + coverage + XState config: effect-analyze ${basename(resolvedPath)} --format statechart-html`,
+        );
+      }
+    }
+  }
 
   if (options.watch) {
     const watchOpts = { ...options, quiet: true };
@@ -2523,7 +2769,8 @@ Effect.runPromise(main).then(
       process.exit(1);
       return;
     }
-    process.exit(0);
+    // Respect an exit code set during the run (e.g. coverage CI gate).
+    process.exit(process.exitCode ?? 0);
   },
   (err: unknown) => {
     const message =

--- a/packages/effect-analyzer/src/index.ts
+++ b/packages/effect-analyzer/src/index.ts
@@ -365,6 +365,38 @@ export type { ConfigItem, ConfigAnalysis } from './config-analyzer';
 export { analyzeMatch } from './match-analyzer';
 export type { MatchAnalysis, MatchSiteInfo, MatchArmInfo } from './match-analyzer';
 
+// State machine analysis + statechart renderers
+export { analyzeStateMachines } from './state-machine';
+export type {
+  StateMachine,
+  StateMachineAnalysis,
+  StateTransition,
+} from './state-machine';
+export { diagnoseStateMachines } from './state-machine-diagnostics';
+export type {
+  StateMachineDiagnostics,
+  StateMachineRejection,
+} from './state-machine-diagnostics';
+export { renderStatechartMermaid, renderStatechartsMermaid } from './output/mermaid-statechart';
+export { renderStatechartSVG, renderStatechartHTML } from './output/svg-statechart';
+export { renderStatechartVisualizerHTML } from './output/statechart-html';
+export { renderXStateConfig } from './output/xstate-config';
+export { computeStateMachineCoverage } from './state-machine-coverage';
+export type {
+  StateMachineCoverage,
+  CoverageFinding,
+  CoverageKind,
+} from './state-machine-coverage';
+export {
+  renderCoverageReport,
+  hasCoverageWarnings,
+  summarizeCoverage,
+} from './output/statechart-coverage';
+export type {
+  CoverageReportOptions,
+  CoverageSummary,
+} from './output/statechart-coverage';
+
 // =============================================================================
 // Platform Detection (GAP 14)
 // =============================================================================

--- a/packages/effect-analyzer/src/output/colocate.ts
+++ b/packages/effect-analyzer/src/output/colocate.ts
@@ -9,6 +9,42 @@ import type { StaticEffectIR, AnalysisStats, DiagramQuality, ServiceArtifact, Pr
 import { renderMermaid, renderEnhancedMermaid, renderPathsMermaid } from './mermaid';
 import { generatePaths } from '../path-generator';
 import { renderExplanation } from './explain';
+import { analyzeStateMachines } from '../state-machine';
+import { computeStateMachineCoverage } from '../state-machine-coverage';
+import { renderStatechartMermaid } from './mermaid-statechart';
+
+/**
+ * Render a "State Machines" section for a file: a coverage-annotated statechart
+ * plus a completeness summary for each detected machine. Empty when none found.
+ */
+const renderStateMachineDocSection = (filePath: string): string => {
+  let machines;
+  try {
+    ({ machines } = analyzeStateMachines(filePath));
+  } catch {
+    return '';
+  }
+  if (machines.length === 0) return '';
+
+  const out: string[] = ['', '---', '', '# State Machines', ''];
+  for (const m of machines) {
+    const cov = computeStateMachineCoverage(m);
+    const alphabet = m.alphabetSource ? ` · alphabet: ${m.alphabetSource}` : '';
+    out.push(`## ${m.name}`, '');
+    out.push(`- **Kind**: ${m.source}${alphabet}`);
+    out.push(
+      `- **Coverage**: ${Math.round(cov.coverageRatio * 100)}% (${cov.handledPairs}/${cov.totalPairs} reachable state×event pairs)`,
+    );
+    const warnings = cov.findings.filter((f) => f.severity === 'warning');
+    if (warnings.length === 0) {
+      out.push('- ✓ No completeness warnings');
+    } else {
+      for (const w of warnings) out.push(`- ⚠ ${w.message}`);
+    }
+    out.push('', '```mermaid', renderStatechartMermaid(m, cov).trim(), '```', '');
+  }
+  return out.join('\n');
+};
 
 /**
  * Derive the output path for a colocated analysis file.
@@ -138,6 +174,7 @@ export const renderColocatedMarkdownForFile = (
   useEnhanced = true,
   qualityByProgram?: ReadonlyMap<string, DiagramQuality>,
   styleGuide = false,
+  filePath?: string,
 ): Effect.Effect<string> =>
   Effect.gen(function* () {
     const sections: string[] = [];
@@ -236,6 +273,20 @@ export const renderColocatedMarkdownForFile = (
         sections.push('', '');
       }
     }
+
+    // File-level state machines (independent of Effect programs).
+    const smFilePath = filePath ?? irs[0]?.metadata.filePath;
+    if (smFilePath) {
+      const stateMachineSection = renderStateMachineDocSection(smFilePath);
+      if (stateMachineSection) {
+        // Give the section a top-level heading when there were no programs.
+        if (irs.length === 0) {
+          sections.push(`# Effect Analysis: ${path.basename(smFilePath)}`, '');
+        }
+        sections.push(stateMachineSection);
+      }
+    }
+
     return sections.join('\n');
   });
 
@@ -259,6 +310,7 @@ export const writeColocatedOutputForFile = (
       useEnhanced,
       qualityByProgram,
       styleGuide,
+      filePath,
     );
 
     yield* Effect.tryPromise({

--- a/packages/effect-analyzer/src/output/mermaid-statechart.ts
+++ b/packages/effect-analyzer/src/output/mermaid-statechart.ts
@@ -1,0 +1,109 @@
+/**
+ * Mermaid `stateDiagram-v2` renderer for plain-Effect state machines.
+ *
+ * Turns the (from, event, to) triples extracted by `analyzeStateMachines`
+ * into an XState-style statechart: states are nodes, events label the edges.
+ *
+ * When a `StateMachineCoverage` is supplied, the diagram is annotated:
+ * unreachable states (including declared-but-orphaned ones) are highlighted,
+ * and unhandled events are listed in a note.
+ */
+
+import type { StateMachine, StateMachineAnalysis } from '../state-machine';
+import type { StateMachineCoverage } from '../state-machine-coverage';
+
+/** Mermaid state ids must be identifier-safe; remember the display label. */
+function sanitizeId(text: string): string {
+  const id = text.replace(/[^a-zA-Z0-9_]/g, '_');
+  return /^[0-9]/.test(id) ? `s_${id}` : id;
+}
+
+function escapeLabel(text: string): string {
+  return text.replace(/"/g, '#quot;');
+}
+
+/** Render a single state machine as a `stateDiagram-v2`. */
+export function renderStatechartMermaid(
+  machine: StateMachine,
+  coverage?: StateMachineCoverage,
+): string {
+  const lines: string[] = ['stateDiagram-v2'];
+  lines.push(`  %% ${machine.name} (${machine.source})`);
+
+  const usedStates = new Set(machine.states);
+  // Unreachable states that actually appear in a transition can be styled
+  // inline; fully-orphaned declared states (no edges) are surfaced in a note,
+  // since mermaid's layout drops disconnected nodes.
+  const unreachableUsed = (coverage?.unreachableStates ?? []).filter((s) =>
+    usedStates.has(s),
+  );
+  const orphanStates = (coverage?.unreachableStates ?? []).filter(
+    (s) => !usedStates.has(s),
+  );
+  const undeclared = new Set(coverage?.undeclaredStates ?? []);
+
+  const idByState = new Map<string, string>();
+  for (const state of machine.states) {
+    const id = sanitizeId(state);
+    idByState.set(state, id);
+    if (id !== state) {
+      lines.push(`  state "${escapeLabel(state)}" as ${id}`);
+    }
+  }
+  const idOf = (s: string): string => idByState.get(s) ?? sanitizeId(s);
+
+  if (machine.initial) {
+    lines.push(`  [*] --> ${idOf(machine.initial)}`);
+  }
+
+  for (const t of machine.transitions) {
+    const label = t.guard
+      ? `${escapeLabel(t.event)} [${escapeLabel(t.guard)}]`
+      : escapeLabel(t.event);
+    lines.push(`  ${idOf(t.from)} --> ${idOf(t.to)}: ${label}`);
+  }
+
+  const hasOutgoing = new Set(machine.transitions.map((t) => t.from));
+  for (const state of machine.states) {
+    if (!hasOutgoing.has(state)) {
+      lines.push(`  ${idOf(state)} --> [*]`);
+    }
+  }
+
+  if (coverage) {
+    if (unreachableUsed.length > 0 || undeclared.size > 0) {
+      lines.push('  classDef unreachable fill:#5b1a1a,stroke:#e53e3e,color:#fff');
+      lines.push('  classDef undeclared fill:#5b431a,stroke:#dd6b20,color:#fff');
+      for (const s of unreachableUsed) lines.push(`  class ${idOf(s)} unreachable`);
+      for (const s of undeclared) lines.push(`  class ${idOf(s)} undeclared`);
+    }
+    const noteParts: string[] = [];
+    if (coverage.unhandledEvents.length > 0) {
+      noteParts.push(`Unhandled events: ${coverage.unhandledEvents.join(', ')}`);
+    }
+    if (orphanStates.length > 0) {
+      noteParts.push(`Unreachable states: ${orphanStates.join(', ')}`);
+    }
+    if (noteParts.length > 0 && machine.initial) {
+      lines.push(`  note right of ${idOf(machine.initial)}`);
+      for (const part of noteParts) lines.push(`    ${part}`);
+      lines.push('  end note');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/** Render every machine found in a file, one diagram each. */
+export function renderStatechartsMermaid(
+  analysis: StateMachineAnalysis,
+  coverages?: readonly StateMachineCoverage[],
+): string {
+  if (analysis.machines.length === 0) {
+    return 'stateDiagram-v2\n  %% No state machines detected';
+  }
+  const byName = new Map(coverages?.map((c) => [c.machine, c]));
+  return analysis.machines
+    .map((m) => renderStatechartMermaid(m, byName.get(m.name)))
+    .join('\n\n');
+}

--- a/packages/effect-analyzer/src/output/statechart-coverage.ts
+++ b/packages/effect-analyzer/src/output/statechart-coverage.ts
@@ -1,0 +1,136 @@
+/**
+ * Renders state-machine coverage results as a Markdown report (with a summary
+ * table for multi-machine / directory runs) and provides pass/fail helpers for
+ * CI gating, including an optional minimum-coverage threshold.
+ */
+
+import { basename } from 'node:path';
+import type { StateMachineCoverage } from '../state-machine-coverage';
+
+export interface CoverageReportOptions {
+  /** Minimum coverage percent (0–100); machines below it fail the report. */
+  readonly minCoverage?: number | undefined;
+}
+
+export interface CoverageSummary {
+  readonly machineCount: number;
+  readonly warningCount: number;
+  readonly minCoverage: number | undefined;
+  readonly belowThreshold: readonly string[];
+  readonly passed: boolean;
+}
+
+const pct = (ratio: number): string => `${Math.round(ratio * 100)}%`;
+
+function list(label: string, items: readonly string[]): string | undefined {
+  if (items.length === 0) return undefined;
+  return `- ${label}: ${items.map((i) => `\`${i}\``).join(', ')}`;
+}
+
+/** True when any machine has a warning-level finding (use for CI exit codes). */
+export function hasCoverageWarnings(
+  coverages: readonly StateMachineCoverage[],
+): boolean {
+  return coverages.some((c) =>
+    c.findings.some((f) => f.severity === 'warning'),
+  );
+}
+
+/** Aggregate pass/fail summary, factoring in an optional coverage threshold. */
+export function summarizeCoverage(
+  coverages: readonly StateMachineCoverage[],
+  minCoverage?: number,
+): CoverageSummary {
+  const warningCount = coverages.reduce(
+    (n, c) => n + c.findings.filter((f) => f.severity === 'warning').length,
+    0,
+  );
+  const belowThreshold =
+    minCoverage === undefined
+      ? []
+      : coverages
+          .filter((c) => c.coverageRatio * 100 < minCoverage)
+          .map((c) => c.machine);
+  return {
+    machineCount: coverages.length,
+    warningCount,
+    minCoverage,
+    belowThreshold,
+    passed: warningCount === 0 && belowThreshold.length === 0,
+  };
+}
+
+export function renderCoverageReport(
+  coverages: readonly StateMachineCoverage[],
+  options: CoverageReportOptions = {},
+): string {
+  if (coverages.length === 0) {
+    return '# State machine coverage\n\nNo state machines found.';
+  }
+
+  const { minCoverage } = options;
+  const summary = summarizeCoverage(coverages, minCoverage);
+  const belowSet = new Set(summary.belowThreshold);
+
+  const lines: string[] = ['# State machine coverage', ''];
+  lines.push(
+    `${summary.machineCount} machine${summary.machineCount === 1 ? '' : 's'}, ${summary.warningCount} warning${summary.warningCount === 1 ? '' : 's'}.` +
+      (minCoverage === undefined ? '' : ` Threshold: ${minCoverage}%.`),
+    '',
+  );
+
+  // Summary table for multi-machine (e.g. directory) runs.
+  if (coverages.length > 1) {
+    lines.push('| Machine | File | Coverage | Warnings |');
+    lines.push('|---------|------|----------|----------|');
+    for (const c of coverages) {
+      const warnings = c.findings.filter((f) => f.severity === 'warning').length;
+      const flag = belowSet.has(c.machine) ? ' ⚠' : '';
+      lines.push(
+        `| ${c.machine} | ${c.file ? basename(c.file) : '—'} | ${pct(c.coverageRatio)}${flag} | ${warnings} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  for (const c of coverages) {
+    const src = c.alphabetSource ? ` _(alphabet: ${c.alphabetSource})_` : '';
+    lines.push(`## ${c.machine}${src}`, '');
+
+    if (!c.alphabetKnown) {
+      lines.push(
+        '> Declared alphabet could not be resolved from the types — completeness was checked only against observed transitions.',
+        '',
+      );
+    }
+
+    lines.push(
+      `Coverage: **${pct(c.coverageRatio)}** (${c.handledPairs}/${c.totalPairs} reachable state×event pairs handled)`,
+      '',
+    );
+
+    const warningLines = [
+      list('⚠ Unhandled events', c.unhandledEvents),
+      list('⚠ Unreachable states', c.unreachableStates),
+      list('⚠ Undeclared states', c.undeclaredStates),
+      list('⚠ Undeclared events', c.undeclaredEvents),
+    ].filter((x): x is string => x !== undefined);
+    if (belowSet.has(c.machine) && minCoverage !== undefined) {
+      warningLines.push(
+        `- ⚠ Coverage ${pct(c.coverageRatio)} is below the ${minCoverage}% threshold`,
+      );
+    }
+    const infoLines = [list('ℹ Final states', c.deadEndStates)].filter(
+      (x): x is string => x !== undefined,
+    );
+
+    if (warningLines.length === 0) {
+      lines.push('✓ No completeness warnings.', '');
+    } else {
+      lines.push(...warningLines, '');
+    }
+    if (infoLines.length > 0) lines.push(...infoLines, '');
+  }
+
+  return lines.join('\n').trimEnd() + '\n';
+}

--- a/packages/effect-analyzer/src/output/statechart-html.ts
+++ b/packages/effect-analyzer/src/output/statechart-html.ts
@@ -1,0 +1,96 @@
+import type { StateMachine } from '../state-machine';
+import type { StateMachineCoverage } from '../state-machine-coverage';
+import { renderCoverageReport } from './statechart-coverage';
+import { renderStatechartSVG } from './svg-statechart';
+import { renderXStateConfig } from './xstate-config';
+
+const esc = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const pct = (ratio: number): string => `${Math.round(ratio * 100)}%`;
+
+export function renderStatechartVisualizerHTML(
+  machines: readonly StateMachine[],
+  coverages: readonly StateMachineCoverage[],
+): string {
+  const byName = new Map(coverages.map((coverage) => [coverage.machine, coverage]));
+  const cards = machines.map((machine) => {
+    const coverage = byName.get(machine.name);
+    const warnings =
+      coverage?.findings.filter((finding) => finding.severity === 'warning').length ?? 0;
+    const config = renderXStateConfig(machine);
+    return `<section class="machine" id="${esc(machine.name)}">
+  <header>
+    <div>
+      <h2>${esc(machine.name)}</h2>
+      <p>${machine.source} / ${machine.transitions.length} transitions / ${machine.states.length} states</p>
+    </div>
+    <div class="${warnings > 0 ? 'badge warn' : 'badge'}">${coverage ? pct(coverage.coverageRatio) : 'n/a'} coverage</div>
+  </header>
+  <div class="grid">
+    <div class="diagram">${renderStatechartSVG(machine, coverage)}</div>
+    <aside>
+      <h3>Coverage</h3>
+      <ul>
+        <li>${warnings} warning${warnings === 1 ? '' : 's'}</li>
+        <li>${coverage?.alphabetKnown ? `alphabet: ${coverage.alphabetSource ?? 'known'}` : 'alphabet: observed only'}</li>
+        <li>initial: ${esc(machine.initial ?? 'unknown')}</li>
+      </ul>
+      <h3>XState export</h3>
+      <pre><code>${esc(config)}</code></pre>
+    </aside>
+  </div>
+</section>`;
+  });
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Effect Statecharts</title>
+<style>
+:root{color-scheme:dark;--bg:#111318;--panel:#1a1f27;--panel2:#202733;--line:#3a414d;--text:#e2e8f0;--muted:#9aa4b2;--accent:#4299e1;--warn:#f6ad55}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,sans-serif}
+main{max-width:1280px;margin:0 auto;padding:28px}
+.hero{display:flex;align-items:flex-end;justify-content:space-between;gap:20px;margin-bottom:24px}
+h1,h2,h3,p{margin:0}
+h1{font-size:28px;line-height:1.15}
+p,li{color:var(--muted)}
+.summary{white-space:pre-wrap;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:16px;margin-bottom:24px;overflow:auto}
+.machine{background:var(--panel);border:1px solid var(--line);border-radius:8px;margin-bottom:24px;overflow:hidden}
+.machine>header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px 18px;border-bottom:1px solid var(--line)}
+.machine h2{font-size:19px}
+.machine h3{font-size:13px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin:0 0 8px}
+.badge{border:1px solid var(--accent);color:#bfdbfe;border-radius:999px;padding:6px 10px;font-size:13px;font-weight:700;white-space:nowrap}
+.badge.warn{border-color:var(--warn);color:#fed7aa}
+.grid{display:grid;grid-template-columns:minmax(0,1fr) 390px;gap:0}
+.diagram{padding:18px;overflow:auto;background:#16191f}
+aside{border-left:1px solid var(--line);padding:18px;background:var(--panel2)}
+ul{padding-left:18px;margin:0 0 18px}
+pre{margin:0;max-height:460px;overflow:auto;border:1px solid var(--line);border-radius:8px;background:#0c0f14;padding:12px}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;line-height:1.45;color:#dbeafe}
+svg{max-width:none}
+@media (max-width:900px){main{padding:16px}.hero{display:block}.grid{grid-template-columns:1fr}aside{border-left:0;border-top:1px solid var(--line)}}
+</style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <div>
+      <h1>Effect Statecharts</h1>
+      <p>Plain Effect source, XState-style visualization, no XState runtime dependency.</p>
+    </div>
+    <div class="badge">${machines.length} machine${machines.length === 1 ? '' : 's'}</div>
+  </section>
+  <pre class="summary">${esc(renderCoverageReport(coverages))}</pre>
+  ${cards.join('\n')}
+</main>
+</body>
+</html>`;
+}

--- a/packages/effect-analyzer/src/output/svg-statechart.ts
+++ b/packages/effect-analyzer/src/output/svg-statechart.ts
@@ -1,0 +1,326 @@
+/**
+ * Self-contained SVG statechart renderer, styled after the XState/Stately
+ * visualizer: dark canvas, a machine-container box, an initial-state dot,
+ * blue event "pills" on the edges, and a final-state marker.
+ *
+ * No external tooling — emits a standalone <svg> (optionally wrapped in HTML).
+ * Layout is a layered left-to-right BFS from the initial state. Edges leaving
+ * a hub fan out to separate lanes so their pills never overlap a node.
+ */
+
+import type { StateMachine } from '../state-machine';
+import type { StateMachineCoverage } from '../state-machine-coverage';
+
+interface Box {
+  readonly state: string;
+  readonly layer: number;
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly h: number;
+}
+
+const C = {
+  bg: '#16191f',
+  container: '#3a414d',
+  title: '#e2e8f0',
+  node: '#222831',
+  nodeStroke: '#4a5568',
+  initStroke: '#4299e1',
+  text: '#e2e8f0',
+  edge: '#8a93a2',
+  pill: '#2b6cb0',
+  pillText: '#ffffff',
+  dot: '#cbd5e0',
+  unreachable: '#e53e3e',
+  undeclared: '#dd6b20',
+  warnText: '#feb2b2',
+} as const;
+
+const NODE_H = 44;
+const V_GAP = 30;
+const MARGIN_X = 84;
+const MARGIN_TOP = 58;
+const MARGIN_BOTTOM = 70;
+
+function esc(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+const nodeWidth = (label: string): number =>
+  Math.max(76, Math.round(label.length * 7.6) + 30);
+
+const pillWidth = (label: string): number => label.length * 6.6 + 18;
+
+/** Event label, with a (truncated) guard condition appended when present. */
+const eventLabel = (event: string, guard?: string): string => {
+  if (!guard) return event;
+  const g = guard.length > 18 ? `${guard.slice(0, 17)}…` : guard;
+  return `${event} [${g}]`;
+};
+
+function assignLayers(
+  machine: StateMachine,
+  states: readonly string[],
+): Map<string, number> {
+  const layer = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+  for (const s of states) adj.set(s, []);
+  for (const t of machine.transitions) adj.get(t.from)?.push(t.to);
+
+  const init = machine.initial ?? states[0];
+  const queue: string[] = [];
+  if (init) {
+    layer.set(init, 0);
+    queue.push(init);
+  }
+  let head = 0;
+  while (head < queue.length) {
+    const u = queue[head++];
+    if (u === undefined) continue;
+    const lu = layer.get(u) ?? 0;
+    for (const v of adj.get(u) ?? []) {
+      if (!layer.has(v)) {
+        layer.set(v, lu + 1);
+        queue.push(v);
+      }
+    }
+  }
+  let maxLayer = 0;
+  for (const l of layer.values()) maxLayer = Math.max(maxLayer, l);
+  for (const s of states) {
+    if (!layer.has(s)) layer.set(s, ++maxLayer);
+  }
+  return layer;
+}
+
+function pill(cx: number, cy: number, label: string): string {
+  const w = pillWidth(label);
+  const h = 19;
+  return (
+    `<rect x="${(cx - w / 2).toFixed(1)}" y="${(cy - h / 2).toFixed(1)}" width="${w.toFixed(1)}" height="${h}" rx="9.5" fill="${C.pill}"/>` +
+    `<text x="${cx.toFixed(1)}" y="${(cy + 4).toFixed(1)}" text-anchor="middle" font-size="11" font-weight="600" fill="${C.pillText}">${esc(label)}</text>`
+  );
+}
+
+export function renderStatechartSVG(
+  machine: StateMachine,
+  coverage?: StateMachineCoverage,
+): string {
+  const unreachableSet = new Set(coverage?.unreachableStates ?? []);
+  const undeclaredSet = new Set(coverage?.undeclaredStates ?? []);
+  // Include declared-but-orphaned states so coverage gaps are visible.
+  const states = [
+    ...machine.states,
+    ...(coverage?.unreachableStates ?? []).filter(
+      (s) => !machine.states.includes(s),
+    ),
+  ];
+
+  const layer = assignLayers(machine, states);
+  let maxLayer = 0;
+  for (const l of layer.values()) maxLayer = Math.max(maxLayer, l);
+
+  const byLayer: string[][] = Array.from({ length: maxLayer + 1 }, () => []);
+  for (const s of states) byLayer[layer.get(s) ?? 0]?.push(s);
+
+  // Horizontal gap must fit the widest event pill plus routing slack.
+  const widestPill = Math.max(
+    40,
+    ...machine.transitions.map((t) => pillWidth(eventLabel(t.event, t.guard))),
+  );
+  const hGap = Math.round(widestPill + 56);
+
+  const colW = byLayer.map((states) => Math.max(76, ...states.map(nodeWidth)));
+  const colX: number[] = [];
+  let cx = MARGIN_X;
+  for (let i = 0; i <= maxLayer; i++) {
+    colX[i] = cx;
+    cx += (colW[i] ?? 76) + hGap;
+  }
+
+  const boxes = new Map<string, Box>();
+  for (let l = 0; l <= maxLayer; l++) {
+    (byLayer[l] ?? []).forEach((s, idx) => {
+      const w = nodeWidth(s);
+      const x = (colX[l] ?? MARGIN_X) + ((colW[l] ?? 76) - w) / 2;
+      const y = MARGIN_TOP + idx * (NODE_H + V_GAP);
+      boxes.set(s, { state: s, layer: l, x, y, w, h: NODE_H });
+    });
+  }
+
+  const maxRows = Math.max(1, ...byLayer.map((s) => s.length));
+  const contentW = (colX[maxLayer] ?? MARGIN_X) + (colW[maxLayer] ?? 76) + MARGIN_X;
+  const contentH =
+    MARGIN_TOP + maxRows * (NODE_H + V_GAP) - V_GAP + MARGIN_BOTTOM;
+  const dipY = contentH - 32;
+
+  const hasOutgoing = new Set(machine.transitions.map((t) => t.from));
+  const edges: string[] = [];
+  const pills: string[] = [];
+
+  // Forward edges fan out by source so lanes/pills don't collide.
+  const forwardBySource = new Map<
+    string,
+    { event: string; to: string; guard: string | undefined }[]
+  >();
+  const otherEdges: {
+    from: string;
+    event: string;
+    to: string;
+    guard: string | undefined;
+  }[] = [];
+  for (const t of machine.transitions) {
+    const from = boxes.get(t.from);
+    const to = boxes.get(t.to);
+    if (!from || !to) continue;
+    if (to.layer > from.layer) {
+      const arr = forwardBySource.get(t.from) ?? [];
+      arr.push({ event: t.event, to: t.to, guard: t.guard });
+      forwardBySource.set(t.from, arr);
+    } else {
+      otherEdges.push({ from: t.from, event: t.event, to: t.to, guard: t.guard });
+    }
+  }
+
+  for (const [fromState, outs] of forwardBySource) {
+    const from = boxes.get(fromState);
+    if (!from) continue;
+    const sx = from.x + from.w;
+    const scy = from.y + from.h / 2;
+    const k = outs.length;
+    // sort by target vertical position for tidy fan
+    outs.sort(
+      (a, b) => (boxes.get(a.to)?.y ?? 0) - (boxes.get(b.to)?.y ?? 0),
+    );
+    outs.forEach((o, i) => {
+      const to = boxes.get(o.to);
+      if (!to) return;
+      const label = eventLabel(o.event, o.guard);
+      const exitY = scy + (i - (k - 1) / 2) * 19;
+      const pillW = pillWidth(label);
+      const pillCx = sx + pillW / 2 + 16;
+      const bendX = sx + widestPill + 30 + i * 8; // staggered vertical lane
+      const tx = to.x;
+      const ty = to.y + to.h / 2;
+      edges.push(
+        `<path d="M ${sx} ${scy} L ${(sx + 10).toFixed(1)} ${exitY.toFixed(1)} ` +
+          `L ${bendX.toFixed(1)} ${exitY.toFixed(1)} L ${bendX.toFixed(1)} ${ty} L ${tx} ${ty}" ` +
+          `fill="none" stroke="${C.edge}" stroke-width="1.5" marker-end="url(#arrow)"/>`,
+      );
+      pills.push(pill(pillCx, exitY, label));
+    });
+  }
+
+  // Edges that don't go to a later layer: route downward ones on the right
+  // side (own lane each) and true back-edges under the diagram.
+  let rightLane = 0;
+  let backLane = 0;
+  for (const o of otherEdges) {
+    const from = boxes.get(o.from);
+    const to = boxes.get(o.to);
+    if (!from || !to) continue;
+    if (to.y > from.y) {
+      // downward (often same column): hug the right side in its own lane
+      const sx = from.x + from.w;
+      const sy = from.y + from.h / 2;
+      const tx = to.x + to.w;
+      const ty = to.y + to.h / 2;
+      const laneX = Math.max(sx, tx) + 22 + rightLane * 20;
+      rightLane++;
+      edges.push(
+        `<path d="M ${sx} ${sy} L ${laneX.toFixed(1)} ${sy} L ${laneX.toFixed(1)} ${ty} L ${tx} ${ty}" ` +
+          `fill="none" stroke="${C.edge}" stroke-width="1.5" marker-end="url(#arrow)"/>`,
+      );
+      pills.push(pill(laneX, (sy + ty) / 2, eventLabel(o.event, o.guard)));
+    } else {
+      // back-edge: route under the diagram
+      const sx = from.x + from.w / 2;
+      const sy = from.y + from.h;
+      const tx = to.x + to.w / 2;
+      const ty = to.y + to.h;
+      const lane = dipY - backLane * 18;
+      backLane++;
+      edges.push(
+        `<path d="M ${sx} ${sy} L ${sx} ${lane} L ${tx} ${lane} L ${tx} ${ty}" ` +
+          `fill="none" stroke="${C.edge}" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arrow)"/>`,
+      );
+      pills.push(pill((sx + tx) / 2, lane, eventLabel(o.event, o.guard)));
+    }
+  }
+
+  const nodes: string[] = [];
+  for (const box of boxes.values()) {
+    const isInitial = box.state === machine.initial;
+    const isFinal = !hasOutgoing.has(box.state);
+    const isUnreachable = unreachableSet.has(box.state);
+    const isUndeclared = undeclaredSet.has(box.state);
+    const stroke = isUnreachable
+      ? C.unreachable
+      : isUndeclared
+        ? C.undeclared
+        : isInitial
+          ? C.initStroke
+          : C.nodeStroke;
+    const sw = isInitial || isUnreachable || isUndeclared ? 2 : 1.4;
+    const dash = isUnreachable ? ' stroke-dasharray="5 3"' : '';
+    nodes.push(
+      `<rect x="${box.x.toFixed(1)}" y="${box.y}" width="${box.w}" height="${box.h}" rx="8" fill="${C.node}" stroke="${stroke}" stroke-width="${sw}"${dash}/>`,
+    );
+    if (isFinal) {
+      nodes.push(
+        `<rect x="${(box.x + 4).toFixed(1)}" y="${box.y + 4}" width="${box.w - 8}" height="${box.h - 8}" rx="6" fill="none" stroke="${C.nodeStroke}" stroke-width="1.2"/>`,
+      );
+    }
+    nodes.push(
+      `<text x="${(box.x + box.w / 2).toFixed(1)}" y="${(box.y + box.h / 2 + 4).toFixed(1)}" text-anchor="middle" font-size="13" font-weight="600" fill="${C.text}">${esc(box.state)}</text>`,
+    );
+  }
+
+  let initialMarker = '';
+  const initBox = machine.initial ? boxes.get(machine.initial) : undefined;
+  if (initBox) {
+    const cyN = initBox.y + initBox.h / 2;
+    const dotX = initBox.x - 30;
+    initialMarker =
+      `<circle cx="${dotX}" cy="${cyN}" r="6.5" fill="${C.dot}"/>` +
+      `<path d="M ${dotX + 7} ${cyN} L ${initBox.x} ${cyN}" stroke="${C.edge}" stroke-width="1.5" marker-end="url(#arrow)"/>`;
+  }
+
+  const unhandled = coverage?.unhandledEvents ?? [];
+  const footerH = unhandled.length > 0 ? 26 : 0;
+
+  const W = Math.round(contentW);
+  const boxH = Math.round(contentH);
+  const H = boxH + footerH;
+  const footer =
+    footerH > 0
+      ? `<text x="26" y="${boxH + 16}" font-size="12" font-weight="600" fill="${C.warnText}">⚠ Unhandled events: ${esc(unhandled.join(', '))}</text>`
+      : '';
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" font-family="system-ui, sans-serif">`,
+    `  <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="${C.edge}"/></marker></defs>`,
+    `  <rect x="0" y="0" width="${W}" height="${H}" fill="${C.bg}"/>`,
+    `  <rect x="12" y="26" width="${W - 24}" height="${boxH - 38}" rx="10" fill="none" stroke="${C.container}" stroke-width="1.5"/>`,
+    `  <text x="26" y="20" font-size="13" font-weight="700" fill="${C.title}">${esc(machine.name)}</text>`,
+    ...edges.map((e) => '  ' + e),
+    initialMarker ? '  ' + initialMarker : '',
+    ...nodes.map((n) => '  ' + n),
+    ...pills.map((p) => '  ' + p),
+    footer ? '  ' + footer : '',
+    '</svg>',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/** Wrap one or more SVG diagrams in a minimal dark HTML page (for viewing). */
+export function renderStatechartHTML(svgs: readonly string[]): string {
+  return [
+    '<!doctype html><html><head><meta charset="utf-8">',
+    `<style>body{margin:0;background:${C.bg};display:flex;flex-direction:column;gap:24px;padding:24px;}</style>`,
+    '</head><body>',
+    ...svgs,
+    '</body></html>',
+  ].join('\n');
+}

--- a/packages/effect-analyzer/src/output/xstate-config.ts
+++ b/packages/effect-analyzer/src/output/xstate-config.ts
@@ -1,0 +1,70 @@
+/**
+ * XState config emitter.
+ *
+ * Turns an extracted plain-Effect state machine into an XState v5
+ * `createMachine({...})` config. The point: you write deterministic
+ * Effect code (no XState), and this gives you a config you can paste
+ * straight into the Stately visualizer (stately.ai/viz) to get the real
+ * interactive statechart — for free.
+ */
+
+import type { StateMachine, StateTransition } from '../state-machine';
+
+/** A single-quoted string literal, escaping backslashes and apostrophes. */
+const str = (value: string): string =>
+  `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+/** A safe JS identifier stays bare; anything else becomes a quoted string. */
+function key(name: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : str(name);
+}
+
+export function renderXStateConfig(machine: StateMachine): string {
+  const byFrom = new Map<string, StateTransition[]>();
+  for (const state of machine.states) byFrom.set(state, []);
+  for (const t of machine.transitions) byFrom.get(t.from)?.push(t);
+
+  const stateLines = machine.states.map((state) => {
+    const outs = byFrom.get(state) ?? [];
+    if (outs.length === 0) {
+      return `    ${key(state)}: { type: 'final' }`;
+    }
+    // Group targets by event. An event with multiple targets, or any guard, is
+    // a conditional transition → emit an array of transition objects so the
+    // config stays valid (no duplicate keys) and guards are preserved.
+    const byEvent = new Map<string, { to: string; guard?: string }[]>();
+    for (const t of outs) {
+      const arr = byEvent.get(t.event) ?? [];
+      if (!arr.some((x) => x.to === t.to && x.guard === t.guard)) {
+        arr.push(t.guard === undefined ? { to: t.to } : { to: t.to, guard: t.guard });
+      }
+      byEvent.set(t.event, arr);
+    }
+    const transitionObj = (x: { to: string; guard?: string }): string =>
+      x.guard === undefined
+        ? `{ target: ${str(x.to)} }`
+        : `{ target: ${str(x.to)}, guard: ${str(x.guard)} }`;
+    const on = [...byEvent]
+      .map(([event, targets]) => {
+        const first = targets[0];
+        return targets.length === 1 && first && first.guard === undefined
+          ? `${key(event)}: ${str(first.to)}`
+          : `${key(event)}: [${targets.map(transitionObj).join(', ')}]`;
+      })
+      .join(', ');
+    return `    ${key(state)}: { on: { ${on} } }`;
+  });
+
+  const lines = [
+    "import { createMachine } from 'xstate';",
+    '',
+    `export const ${machine.name}Machine = createMachine({`,
+    `  id: ${str(machine.name)},`,
+  ];
+  if (machine.initial) lines.push(`  initial: ${str(machine.initial)},`);
+  lines.push('  states: {');
+  lines.push(stateLines.join(',\n'));
+  lines.push('  }');
+  lines.push('});');
+  return lines.join('\n');
+}

--- a/packages/effect-analyzer/src/state-machine-cache.test.ts
+++ b/packages/effect-analyzer/src/state-machine-cache.test.ts
@@ -1,0 +1,36 @@
+import { writeFileSync, utimesSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { analyzeStateMachines } from './state-machine';
+
+const machineSource = (open: string) => `
+import { Match } from 'effect'
+export const m = (s: 'Closed' | '${open}', e: 'Toggle'): 'Closed' | '${open}' =>
+  Match.value([s, e] as const).pipe(
+    Match.when(['Closed', 'Toggle'], () => '${open}' as const),
+    Match.orElse(() => s),
+  )
+`;
+
+describe('analysis cache', () => {
+  it('re-analyzes after the file changes on disk (mtime invalidation)', () => {
+    const path = join(tmpdir(), `sm-cache-${process.pid}-${Date.now()}.ts`);
+    try {
+      writeFileSync(path, machineSource('Open'));
+      const first = analyzeStateMachines(path).machines;
+      expect(first[0]?.states).toContain('Open');
+
+      // Rewrite with a different target and bump mtime to guarantee a change.
+      writeFileSync(path, machineSource('Ajar'));
+      const future = Date.now() / 1000 + 10;
+      utimesSync(path, future, future);
+
+      const second = analyzeStateMachines(path).machines;
+      expect(second[0]?.states).toContain('Ajar');
+      expect(second[0]?.states).not.toContain('Open');
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+});

--- a/packages/effect-analyzer/src/state-machine-coverage.test.ts
+++ b/packages/effect-analyzer/src/state-machine-coverage.test.ts
@@ -1,0 +1,171 @@
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { analyzeStateMachines } from './state-machine';
+import { renderColocatedMarkdownForFile } from './output/colocate';
+import { computeStateMachineCoverage } from './state-machine-coverage';
+import {
+  renderCoverageReport,
+  hasCoverageWarnings,
+  summarizeCoverage,
+} from './output/statechart-coverage';
+import { renderStatechartMermaid } from './output/mermaid-statechart';
+import { renderStatechartSVG } from './output/svg-statechart';
+import { renderStatechartVisualizerHTML } from './output/statechart-html';
+
+const fixtures = (name: string) => join(__dirname, '__fixtures__', name);
+vi.setConfig({ testTimeout: 15_000 });
+
+function coverageFor(file: string, machineName: string) {
+  const { machines } = analyzeStateMachines(fixtures(file));
+  const machine = machines.find((m) => m.name === machineName);
+  if (!machine) throw new Error(`machine ${machineName} not found`);
+  return computeStateMachineCoverage(machine);
+}
+
+describe('computeStateMachineCoverage', () => {
+  it('flags unhandled events and unreachable states on an incomplete machine', () => {
+    const cov = coverageFor('state-machine-schema.ts', 'checkoutTransition');
+    expect(cov.alphabetKnown).toBe(true);
+    expect(cov.alphabetSource).toBe('schema');
+    expect(cov.unhandledEvents).toEqual(['Cancel']);
+    expect(cov.unreachableStates).toEqual(['Cancelled']);
+    expect(cov.undeclaredStates).toEqual([]);
+    expect(cov.undeclaredEvents).toEqual([]);
+    expect(cov.deadEndStates).toEqual(['Confirmed']);
+
+    const kinds = cov.findings.map((f) => f.kind).sort();
+    expect(kinds).toEqual([
+      'dead-end-state',
+      'unhandled-event',
+      'unreachable-state',
+    ]);
+  });
+
+  it('computes a coverage ratio over reachable, non-final states', () => {
+    const cov = coverageFor('state-machine-schema.ts', 'checkoutTransition');
+    // active states {Cart, Payment} × 3 declared events = 6 possible pairs
+    // handled: Cart→Checkout, Payment→Pay = 2
+    expect(cov.totalPairs).toBe(6);
+    expect(cov.handledPairs).toBe(2);
+    expect(cov.coverageRatio).toBeCloseTo(2 / 6, 5);
+  });
+
+  it('reports a complete machine as having no warnings', () => {
+    const cov = coverageFor('state-machine.ts', 'supportTransitions');
+    expect(cov.alphabetKnown).toBe(true);
+    expect(cov.unhandledEvents).toEqual([]);
+    expect(cov.unreachableStates).toEqual([]);
+    expect(cov.undeclaredStates).toEqual([]);
+    expect(cov.undeclaredEvents).toEqual([]);
+    expect(cov.findings.filter((f) => f.severity === 'warning')).toEqual([]);
+  });
+
+  it('degrades gracefully when the alphabet is unknown', () => {
+    const cov = coverageFor('state-machine-advanced.ts', 'gateTransitions');
+    expect(cov.alphabetKnown).toBe(false);
+    // no declared alphabet ⇒ no unhandled/undeclared findings
+    expect(cov.unhandledEvents).toEqual([]);
+    expect(cov.undeclaredStates).toEqual([]);
+    expect(cov.unreachableStates).toEqual([]);
+  });
+});
+
+describe('coverage report + annotations', () => {
+  it('renders a markdown report and flags warnings for CI', () => {
+    const cov = coverageFor('state-machine-schema.ts', 'checkoutTransition');
+    const report = renderCoverageReport([cov]);
+    expect(report).toContain('# State machine coverage');
+    expect(report).toContain('Unhandled events');
+    expect(report).toContain('`Cancel`');
+    expect(report).toContain('`Cancelled`');
+    expect(hasCoverageWarnings([cov])).toBe(true);
+  });
+
+  it('reports no warnings for a complete machine', () => {
+    const cov = coverageFor('state-machine.ts', 'supportTransitions');
+    expect(renderCoverageReport([cov])).toContain('No completeness warnings');
+    expect(hasCoverageWarnings([cov])).toBe(false);
+  });
+
+  it('annotates the mermaid statechart with a coverage note', () => {
+    const { machines } = analyzeStateMachines(fixtures('state-machine-schema.ts'));
+    const machine = machines.find((m) => m.name === 'checkoutTransition')!;
+    const cov = computeStateMachineCoverage(machine);
+    const mermaid = renderStatechartMermaid(machine, cov);
+    expect(mermaid).toContain('note right of Cart');
+    expect(mermaid).toContain('Unhandled events: Cancel');
+    expect(mermaid).toContain('Unreachable states: Cancelled');
+  });
+
+  it('renders a summary table for multi-machine runs', () => {
+    const { machines } = analyzeStateMachines(fixtures('state-machine.ts'));
+    const covs = machines.map(computeStateMachineCoverage);
+    const report = renderCoverageReport(covs);
+    expect(report).toContain('| Machine | File | Coverage | Warnings |');
+    expect(report).toContain('supportTransitions');
+    expect(report).toContain('docTransition');
+  });
+
+  it('applies a minimum-coverage threshold', () => {
+    const { machines } = analyzeStateMachines(fixtures('state-machine.ts'));
+    const covs = machines.map(computeStateMachineCoverage);
+    // docTransition is 50%, supportTransitions 42% — both below 60
+    const summary = summarizeCoverage(covs, 60);
+    expect(summary.passed).toBe(false);
+    expect([...summary.belowThreshold].sort()).toEqual([
+      'docTransition',
+      'supportTransitions',
+    ]);
+    const report = renderCoverageReport(covs, { minCoverage: 60 });
+    expect(report).toContain('Threshold: 60%');
+    expect(report).toContain('below the 60% threshold');
+  });
+
+  it('passes the summary when everything is complete and above threshold', () => {
+    const cov = coverageFor('state-machine.ts', 'supportTransitions');
+    expect(summarizeCoverage([cov], 40).passed).toBe(true);
+    expect(summarizeCoverage([cov]).passed).toBe(true);
+  });
+
+  it('annotates the SVG statechart with the orphan state and footer', () => {
+    const { machines } = analyzeStateMachines(fixtures('state-machine-schema.ts'));
+    const machine = machines.find((m) => m.name === 'checkoutTransition')!;
+    const cov = computeStateMachineCoverage(machine);
+    const svg = renderStatechartSVG(machine, cov);
+    // orphan state is drawn (dashed) and the unhandled-events footer is present
+    expect(svg).toContain('Cancelled');
+    expect(svg).toContain('stroke-dasharray');
+    expect(svg).toContain('Unhandled events: Cancel');
+  });
+
+  it('renders a local visualizer page with SVG, coverage, and XState config', () => {
+    const { machines } = analyzeStateMachines(fixtures('state-machine.ts'));
+    const covs = machines.map(computeStateMachineCoverage);
+    const html = renderStatechartVisualizerHTML(machines, covs);
+    expect(html).toContain('<title>Effect Statecharts</title>');
+    expect(html).toContain('Plain Effect source, XState-style visualization');
+    expect(html).toContain('supportTransitions');
+    expect(html).toContain('createMachine');
+    expect(html).toContain('# State machine coverage');
+  });
+
+  it('folds a State Machines section into the colocated doc', async () => {
+    const md = await Effect.runPromise(
+      renderColocatedMarkdownForFile(
+        [],
+        'TB',
+        true,
+        undefined,
+        false,
+        fixtures('state-machine-schema.ts'),
+      ),
+    );
+    expect(md).toContain('# State Machines');
+    expect(md).toContain('## checkoutTransition');
+    expect(md).toContain('alphabet: schema');
+    expect(md).toContain('Coverage');
+    expect(md).toContain('stateDiagram-v2');
+    expect(md).toContain('Cancel');
+  });
+});

--- a/packages/effect-analyzer/src/state-machine-coverage.ts
+++ b/packages/effect-analyzer/src/state-machine-coverage.ts
@@ -1,0 +1,208 @@
+/**
+ * State machine coverage / completeness analysis.
+ *
+ * Cross-checks a machine's extracted transitions against its declared alphabet
+ * (the full set of states/events from its types — a tagged union or a
+ * Schema-derived type). This turns the statechart from "a drawing" into
+ * "a verified machine": it reports events nothing handles, states nothing
+ * reaches, and symbols that drifted away from the declared types.
+ */
+
+import type { StateMachine } from './state-machine';
+
+export type CoverageKind =
+  | 'unhandled-event'
+  | 'unreachable-state'
+  | 'undeclared-state'
+  | 'undeclared-event'
+  | 'dead-end-state';
+
+export interface CoverageFinding {
+  readonly kind: CoverageKind;
+  readonly severity: 'warning' | 'info';
+  readonly symbol: string;
+  readonly message: string;
+}
+
+export interface StateMachineCoverage {
+  readonly machine: string;
+  readonly file: string | undefined;
+  /** True when both declared alphabets were resolvable from the types. */
+  readonly alphabetKnown: boolean;
+  readonly alphabetSource: 'schema' | 'tagged-union' | undefined;
+  readonly declaredStates: readonly string[];
+  readonly declaredEvents: readonly string[];
+  readonly usedStates: readonly string[];
+  readonly usedEvents: readonly string[];
+  /** Declared events that no transition uses. */
+  readonly unhandledEvents: readonly string[];
+  /** States not reachable from the initial state (and not the initial itself). */
+  readonly unreachableStates: readonly string[];
+  /** Used states/events absent from the declared alphabet (drift / typo). */
+  readonly undeclaredStates: readonly string[];
+  readonly undeclaredEvents: readonly string[];
+  /** Reachable states with no outgoing transition (treated as final). */
+  readonly deadEndStates: readonly string[];
+  readonly handledPairs: number;
+  readonly totalPairs: number;
+  /** handledPairs / totalPairs in [0,1]; 1 when there is nothing to cover. */
+  readonly coverageRatio: number;
+  readonly findings: readonly CoverageFinding[];
+}
+
+function unique(xs: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}
+
+/** States reachable from `initial` by following transitions. */
+function reachableFrom(
+  initial: string | undefined,
+  adjacency: Map<string, Set<string>>,
+): Set<string> {
+  const reachable = new Set<string>();
+  if (!initial) return reachable;
+  const queue = [initial];
+  reachable.add(initial);
+  let head = 0;
+  while (head < queue.length) {
+    const u = queue[head++];
+    if (u === undefined) continue;
+    for (const v of adjacency.get(u) ?? []) {
+      if (!reachable.has(v)) {
+        reachable.add(v);
+        queue.push(v);
+      }
+    }
+  }
+  return reachable;
+}
+
+export function computeStateMachineCoverage(
+  machine: StateMachine,
+): StateMachineCoverage {
+  const usedStates = machine.states;
+  const usedEvents = unique(machine.transitions.map((t) => t.event));
+
+  const alphabetKnown =
+    machine.declaredStates !== undefined && machine.declaredEvents !== undefined;
+  // Fall back to observed symbols when the alphabet couldn't be resolved.
+  const declaredStates = machine.declaredStates ?? usedStates;
+  const declaredEvents = machine.declaredEvents ?? usedEvents;
+  const stateSet = new Set(declaredStates);
+  const eventSet = new Set(declaredEvents);
+
+  // Build adjacency for reachability + outgoing/incoming bookkeeping.
+  const adjacency = new Map<string, Set<string>>();
+  const hasOutgoing = new Set<string>();
+  for (const t of machine.transitions) {
+    hasOutgoing.add(t.from);
+    const set = adjacency.get(t.from) ?? new Set<string>();
+    set.add(t.to);
+    adjacency.set(t.from, set);
+  }
+  const reachable = reachableFrom(machine.initial, adjacency);
+
+  // The universe of states to judge reachability against: declared ∪ used.
+  const allStates = unique([...declaredStates, ...usedStates]);
+
+  const unhandledEvents = alphabetKnown
+    ? declaredEvents.filter((e) => !usedEvents.includes(e))
+    : [];
+  const unreachableStates = allStates.filter(
+    (s) => s !== machine.initial && !reachable.has(s),
+  );
+  const undeclaredStates = alphabetKnown
+    ? usedStates.filter((s) => !stateSet.has(s))
+    : [];
+  const undeclaredEvents = alphabetKnown
+    ? usedEvents.filter((e) => !eventSet.has(e))
+    : [];
+  const deadEndStates = [...reachable].filter((s) => !hasOutgoing.has(s));
+
+  // Coverage = handled (state,event) pairs over reachable, non-final states.
+  const activeStates = [...reachable].filter((s) => hasOutgoing.has(s));
+  const handledPerState = new Map<string, Set<string>>();
+  for (const t of machine.transitions) {
+    const set = handledPerState.get(t.from) ?? new Set<string>();
+    set.add(t.event);
+    handledPerState.set(t.from, set);
+  }
+  const totalPairs = activeStates.length * declaredEvents.length;
+  let handledPairs = 0;
+  for (const s of activeStates) {
+    const handled = handledPerState.get(s);
+    if (!handled) continue;
+    for (const e of declaredEvents) if (handled.has(e)) handledPairs++;
+  }
+  const coverageRatio = totalPairs === 0 ? 1 : handledPairs / totalPairs;
+
+  const findings: CoverageFinding[] = [];
+  for (const e of unhandledEvents) {
+    findings.push({
+      kind: 'unhandled-event',
+      severity: 'warning',
+      symbol: e,
+      message: `Event "${e}" is declared but no state handles it.`,
+    });
+  }
+  for (const s of unreachableStates) {
+    findings.push({
+      kind: 'unreachable-state',
+      severity: 'warning',
+      symbol: s,
+      message: `State "${s}" is not reachable from the initial state.`,
+    });
+  }
+  for (const s of undeclaredStates) {
+    findings.push({
+      kind: 'undeclared-state',
+      severity: 'warning',
+      symbol: s,
+      message: `State "${s}" is used in a transition but not in the declared states.`,
+    });
+  }
+  for (const e of undeclaredEvents) {
+    findings.push({
+      kind: 'undeclared-event',
+      severity: 'warning',
+      symbol: e,
+      message: `Event "${e}" is used in a transition but not in the declared events.`,
+    });
+  }
+  for (const s of deadEndStates) {
+    findings.push({
+      kind: 'dead-end-state',
+      severity: 'info',
+      symbol: s,
+      message: `State "${s}" has no outgoing transitions (treated as final).`,
+    });
+  }
+
+  return {
+    machine: machine.name,
+    file: machine.location?.filePath,
+    alphabetKnown,
+    alphabetSource: machine.alphabetSource,
+    declaredStates,
+    declaredEvents,
+    usedStates,
+    usedEvents,
+    unhandledEvents,
+    unreachableStates,
+    undeclaredStates,
+    undeclaredEvents,
+    deadEndStates,
+    handledPairs,
+    totalPairs,
+    coverageRatio,
+    findings,
+  };
+}

--- a/packages/effect-analyzer/src/state-machine-diagnostics.test.ts
+++ b/packages/effect-analyzer/src/state-machine-diagnostics.test.ts
@@ -1,0 +1,42 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { diagnoseStateMachines } from './state-machine-diagnostics';
+
+const nearMiss = join(__dirname, '__fixtures__', 'state-machine-near-miss.ts');
+
+describe('diagnoseStateMachines', () => {
+  it('finds no real machines in the near-miss fixture', () => {
+    expect(diagnoseStateMachines(nearMiss).machines).toEqual([]);
+  });
+
+  it('explains a config-shaped table whose events lead nowhere', () => {
+    const { rejected } = diagnoseStateMachines(nearMiss);
+    const r = rejected.find((x) => x.name === 'settingsTransitions');
+    expect(r?.kind).toBe('transition-table');
+    expect(r?.reason).toMatch(/no event targets another state/);
+    expect(r?.location?.line).toBeGreaterThan(0);
+  });
+
+  it('explains a Match.when handler that returns a non-literal state', () => {
+    const { rejected } = diagnoseStateMachines(nearMiss);
+    const r = rejected.find((x) => x.name === 'computedTransition');
+    expect(r?.kind).toBe('match');
+    expect(r?.reason).toMatch(/does not return a literal next state/);
+  });
+
+  it('explains single-level Match.tags as variant dispatch', () => {
+    const { rejected } = diagnoseStateMachines(nearMiss);
+    const r = rejected.find((x) => x.name === 'describe');
+    expect(r?.reason).toMatch(/variant dispatch/);
+    expect(r?.hint).toMatch(/nest/i);
+  });
+
+  it('does not flag a real machine as a near-miss', () => {
+    const fixture = join(__dirname, '__fixtures__', 'state-machine.ts');
+    const { machines, rejected } = diagnoseStateMachines(fixture);
+    expect(machines.length).toBeGreaterThan(0);
+    const names = new Set(rejected.map((r) => r.name));
+    expect(names.has('supportTransitions')).toBe(false);
+    expect(names.has('docTransition')).toBe(false);
+  });
+});

--- a/packages/effect-analyzer/src/state-machine-diagnostics.ts
+++ b/packages/effect-analyzer/src/state-machine-diagnostics.ts
@@ -1,0 +1,267 @@
+/**
+ * State machine diagnostics.
+ *
+ * Explains why a declaration that looks like a state machine was not
+ * recognized. The CLI uses this so a failed `--format statechart-*` run teaches
+ * the convention instead of printing "no machines found".
+ *
+ * This scanner is intentionally independent of the extraction code: it
+ * re-derives near-miss candidates with its own light AST checks so it stays
+ * stable while the extractor evolves.
+ */
+
+import { Node, Project, SyntaxKind } from 'ts-morph';
+import type { SourceLocation } from './types';
+import { analyzeStateMachines, type StateMachine } from './state-machine';
+
+export interface StateMachineRejection {
+  readonly name: string;
+  readonly kind: 'transition-table' | 'match';
+  readonly reason: string;
+  readonly hint: string;
+  readonly location: SourceLocation | undefined;
+}
+
+export interface StateMachineDiagnostics {
+  readonly machines: readonly StateMachine[];
+  readonly rejected: readonly StateMachineRejection[];
+}
+
+function unwrap(node: Node): Node {
+  let cur = node;
+  for (;;) {
+    const k = cur.getKind();
+    if (
+      k === SyntaxKind.AsExpression ||
+      k === SyntaxKind.SatisfiesExpression ||
+      k === SyntaxKind.ParenthesizedExpression ||
+      k === SyntaxKind.TypeAssertionExpression
+    ) {
+      cur = (cur as unknown as { getExpression(): Node }).getExpression();
+      continue;
+    }
+    return cur;
+  }
+}
+
+function stringVal(node: Node | undefined): string | undefined {
+  if (!node) return undefined;
+  const u = unwrap(node);
+  return Node.isStringLiteral(u) ? u.getLiteralValue() : undefined;
+}
+
+function propName(prop: Node): string | undefined {
+  if (!Node.isPropertyAssignment(prop)) return undefined;
+  const n = prop.getNameNode();
+  if (Node.isStringLiteral(n)) return n.getLiteralValue();
+  if (Node.isIdentifier(n)) return n.getText();
+  return undefined;
+}
+
+/** Resolve a table leaf to its target state: string, `{ target }`, or array. */
+function leafTarget(node: Node | undefined): string | undefined {
+  if (!node) return undefined;
+  const u = unwrap(node);
+  if (Node.isStringLiteral(u)) return u.getLiteralValue();
+  if (Node.isObjectLiteralExpression(u)) {
+    const t = u.getProperty('target');
+    return t ? stringVal((t as { getInitializer?(): Node | undefined }).getInitializer?.()) : undefined;
+  }
+  if (Node.isArrayLiteralExpression(u)) {
+    return leafTarget(u.getElements()[0]);
+  }
+  return undefined;
+}
+
+function returnsLiteralState(handler: Node): boolean {
+  if (!Node.isArrowFunction(handler) && !Node.isFunctionExpression(handler)) {
+    return false;
+  }
+  const isLiteral = (n: Node | undefined): boolean => {
+    if (!n) return false;
+    const u = unwrap(n);
+    if (Node.isStringLiteral(u)) return true;
+    return Node.isObjectLiteralExpression(u) && u.getProperty('_tag') !== undefined;
+  };
+  const body = handler.getBody();
+  if (!Node.isBlock(body)) return isLiteral(body);
+  return body
+    .getDescendantsOfKind(SyntaxKind.ReturnStatement)
+    .some((r) => isLiteral(r.getExpression()));
+}
+
+function ownerOf(node: Node): { name: string; nameNode: Node } | undefined {
+  let cur: Node | undefined = node.getParent();
+  while (cur) {
+    if (Node.isVariableDeclaration(cur)) {
+      return { name: cur.getName(), nameNode: cur.getNameNode() };
+    }
+    if (Node.isFunctionDeclaration(cur)) {
+      const name = cur.getName();
+      if (name) return { name, nameNode: cur.getNameNodeOrThrow() };
+    }
+    cur = cur.getParent();
+  }
+  return undefined;
+}
+
+function locOf(node: Node, filePath: string): SourceLocation {
+  const sf = node.getSourceFile();
+  const offset = node.getStart();
+  const { line, column } = sf.getLineAndColumnAtPos(offset);
+  return { filePath, line, column, offset };
+}
+
+function isMatchCall(call: Node, method: string): boolean {
+  if (!Node.isCallExpression(call)) return false;
+  const expr = call.getExpression();
+  return (
+    Node.isPropertyAccessExpression(expr) &&
+    expr.getName() === method &&
+    expr.getExpression().getText() === 'Match'
+  );
+}
+
+export function diagnoseStateMachines(
+  filePath: string,
+  source?: string,
+): StateMachineDiagnostics {
+  const project = new Project({ useInMemoryFileSystem: !!source });
+  const sf = source
+    ? project.createSourceFile(filePath, source, { overwrite: true })
+    : project.addSourceFileAtPath(filePath);
+
+  const { machines } = analyzeStateMachines(filePath, source);
+  const matched = new Set(machines.map((m) => m.name));
+  const rejected: StateMachineRejection[] = [];
+  const reported = new Set<string>();
+
+  const add = (
+    name: string,
+    kind: StateMachineRejection['kind'],
+    reason: string,
+    hint: string,
+    anchor: Node,
+  ): void => {
+    if (matched.has(name) || reported.has(name)) return;
+    reported.add(name);
+    rejected.push({ name, kind, reason, hint, location: locOf(anchor, filePath) });
+  };
+
+  // A) Object literals that look like a transition table.
+  for (const decl of sf.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+    const name = decl.getName();
+    if (matched.has(name)) continue;
+    const init = decl.getInitializer();
+    if (!init) continue;
+    const hasSatisfies = init.getKind() === SyntaxKind.SatisfiesExpression;
+    const intentional =
+      hasSatisfies || /transition|machine|states?|fsm|workflow/i.test(name);
+    if (!intentional) continue;
+    const obj = unwrap(init);
+    if (!Node.isObjectLiteralExpression(obj)) continue;
+    const props = obj.getProperties().filter((p) => Node.isPropertyAssignment(p));
+    if (props.length === 0) continue;
+
+    const keys = new Set(
+      props.map(propName).filter((k): k is string => k !== undefined),
+    );
+    let hasObjectValue = false;
+    let hasLeaf = false;
+    let targetsAnotherState = false;
+    for (const p of props) {
+      if (!Node.isPropertyAssignment(p)) continue;
+      const value = unwrap(p.getInitializer() ?? p);
+      if (!Node.isObjectLiteralExpression(value)) continue;
+      hasObjectValue = true;
+      for (const ev of value.getProperties()) {
+        if (!Node.isPropertyAssignment(ev)) continue;
+        const target = leafTarget(ev.getInitializer());
+        if (target !== undefined) {
+          hasLeaf = true;
+          if (keys.has(target)) targetsAnotherState = true;
+        }
+      }
+    }
+
+    if (!hasObjectValue) {
+      add(
+        name,
+        'transition-table',
+        'values are not nested event→state objects',
+        'shape it as `{ State: { Event: NextState } }`',
+        decl.getNameNode(),
+      );
+    } else if (!hasLeaf) {
+      add(
+        name,
+        'transition-table',
+        'no event maps to a state',
+        'a leaf must be a state string or `{ target: State }`',
+        decl.getNameNode(),
+      );
+    } else if (!targetsAnotherState) {
+      add(
+        name,
+        'transition-table',
+        'no event targets another state, so it reads as config, not a machine',
+        'at least one event should lead to a different state',
+        decl.getNameNode(),
+      );
+    }
+  }
+
+  // B) Match.when arms whose owner produced no machine.
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    if (!isMatchCall(call, 'when')) continue;
+    const owner = ownerOf(call);
+    if (!owner || matched.has(owner.name) || reported.has(owner.name)) continue;
+    const [pattern, handler] = call.getArguments();
+    const tuple = pattern ? unwrap(pattern) : undefined;
+    if (
+      !tuple ||
+      !Node.isArrayLiteralExpression(tuple) ||
+      tuple.getElements().length !== 2
+    ) {
+      add(
+        owner.name,
+        'match',
+        'a Match.when pattern is not a 2-tuple [state, event]',
+        "use Match.when(['State', 'Event'], () => nextState)",
+        owner.nameNode,
+      );
+    } else if (!handler || !returnsLiteralState(handler)) {
+      add(
+        owner.name,
+        'match',
+        'a Match.when handler does not return a literal next state',
+        "return { _tag: 'Next' } or a state string",
+        owner.nameNode,
+      );
+    }
+  }
+
+  // C) Single-level Match.tags (variant dispatch mistaken for a machine).
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    if (!isMatchCall(call, 'tags')) continue;
+    const owner = ownerOf(call);
+    if (!owner || matched.has(owner.name) || reported.has(owner.name)) continue;
+    const [arg] = call.getArguments();
+    const obj = arg ? unwrap(arg) : undefined;
+    const nested =
+      obj !== undefined &&
+      Node.isObjectLiteralExpression(obj) &&
+      obj.getProperties().some((p) => p.getText().includes('Match.'));
+    if (!nested) {
+      add(
+        owner.name,
+        'match',
+        'single-level Match.tags reads as variant dispatch, not transitions',
+        'nest Match.value(event).pipe(Match.tags({...})) inside each state',
+        owner.nameNode,
+      );
+    }
+  }
+
+  return { machines, rejected };
+}

--- a/packages/effect-analyzer/src/state-machine.test.ts
+++ b/packages/effect-analyzer/src/state-machine.test.ts
@@ -1,0 +1,325 @@
+import { join } from 'node:path';
+import { Project } from 'ts-morph';
+import { describe, expect, it, vi } from 'vitest';
+import { analyzeStateMachines } from './state-machine';
+import { renderStatechartMermaid } from './output/mermaid-statechart';
+import { renderStatechartSVG } from './output/svg-statechart';
+import { renderXStateConfig } from './output/xstate-config';
+
+const fixture = join(__dirname, '__fixtures__', 'state-machine.ts');
+vi.setConfig({ testTimeout: 15_000 });
+const advancedFixture = join(
+  __dirname,
+  '__fixtures__',
+  'state-machine-advanced.ts',
+);
+
+describe('analyzeStateMachines', () => {
+  it('extracts both machines from the fixture', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    expect(machines.map((m) => m.name).sort()).toEqual([
+      'docTransition',
+      'supportTransitions',
+    ]);
+  });
+
+  it('extracts triples from the declarative transition table', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const support = machines.find((m) => m.name === 'supportTransitions');
+    expect(support?.source).toBe('transition-table');
+    expect(support?.initial).toBe('Triage');
+    expect(support?.transitions).toContainEqual({
+      from: 'Triage',
+      event: 'RefundRequested',
+      to: 'Refund',
+    });
+    expect(support?.transitions).toContainEqual({
+      from: 'Refund',
+      event: 'Resolved',
+      to: 'Answered',
+    });
+  });
+
+  it('extracts triples from the Match.when tuple function', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const doc = machines.find((m) => m.name === 'docTransition');
+    expect(doc?.source).toBe('match');
+    expect(doc?.transitions).toContainEqual({
+      from: 'Draft',
+      event: 'Submit',
+      to: 'Review',
+    });
+    expect(doc?.transitions).toContainEqual({
+      from: 'Review',
+      event: 'Reject',
+      to: 'Draft',
+    });
+  });
+});
+
+describe('hardened detection', () => {
+  it('reads block-body Match.when handlers', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const job = machines.find((m) => m.name === 'jobTransition');
+    expect(job?.transitions).toContainEqual({
+      from: 'Queued',
+      event: 'Start',
+      to: 'Running',
+    });
+    expect(job?.transitions).toContainEqual({
+      from: 'Running',
+      event: 'Error',
+      to: 'Failed',
+    });
+  });
+
+  it('emits one edge per target for a guarded (multi-return) handler', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const job = machines.find((m) => m.name === 'jobTransition');
+    const finishTargets = job?.transitions
+      .filter((t) => t.from === 'Running' && t.event === 'Finish')
+      .map((t) => t.to)
+      .sort();
+    expect(finishTargets).toEqual(['Done', 'Failed']);
+  });
+
+  it('picks initial from a sibling initial declaration', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const job = machines.find((m) => m.name === 'jobTransition');
+    expect(job?.initial).toBe('Queued');
+  });
+
+  it('honors an @initial annotation over the first table key', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const gate = machines.find((m) => m.name === 'gateTransitions');
+    // first key is "Closed"; annotation overrides to "Open"
+    expect(gate?.initial).toBe('Open');
+  });
+});
+
+const literalFixture = join(__dirname, '__fixtures__', 'state-machine-literal.ts');
+const effectIdiomsFixture = join(
+  __dirname,
+  '__fixtures__',
+  'state-machine-effect-idioms.ts',
+);
+
+describe('detection depth', () => {
+  it('extracts a string-literal-union machine (no _tag) with its alphabet', () => {
+    const { machines } = analyzeStateMachines(literalFixture);
+    const light = machines.find((m) => m.name === 'lightTransition');
+    expect(light?.transitions).toContainEqual({
+      from: 'Red',
+      event: 'Tick',
+      to: 'Green',
+    });
+    expect([...(light?.declaredStates ?? [])].sort()).toEqual([
+      'Green',
+      'Red',
+      'Yellow',
+    ]);
+    expect(light?.declaredEvents).toEqual(['Tick']);
+  });
+
+  it('captures the guard condition on a conditional transition', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const job = machines.find((m) => m.name === 'jobTransition');
+    const done = job?.transitions.find(
+      (t) => t.from === 'Running' && t.event === 'Finish' && t.to === 'Done',
+    );
+    const failed = job?.transitions.find(
+      (t) => t.from === 'Running' && t.event === 'Finish' && t.to === 'Failed',
+    );
+    expect(done?.guard).toBe('Math.random() > 0.5');
+    expect(failed?.guard).toBeUndefined();
+  });
+
+  it('renders guards in mermaid and xstate config', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const job = machines.find((m) => m.name === 'jobTransition')!;
+    expect(renderStatechartMermaid(job)).toContain(
+      'Running --> Done: Finish [Math.random() > 0.5]',
+    );
+    const config = renderXStateConfig(job);
+    expect(config).toContain(
+      `Finish: [{ target: 'Done', guard: 'Math.random() > 0.5' }, { target: 'Failed' }]`,
+    );
+  });
+
+  it('reads XState-style table leaves without requiring XState', () => {
+    const { machines } = analyzeStateMachines(effectIdiomsFixture);
+    const workflow = machines.find((m) => m.name === 'workflowTransitions');
+    expect(workflow?.transitions).toContainEqual({
+      from: 'Idle',
+      event: 'Start',
+      to: 'Active',
+      guard: 'canStart',
+    });
+    expect(workflow?.transitions).toContainEqual({
+      from: 'Active',
+      event: 'Stop',
+      to: 'Closed',
+    });
+    expect(workflow?.transitions).toContainEqual({
+      from: 'Active',
+      event: 'Fail',
+      to: 'Closed',
+      guard: 'isFatal',
+    });
+    expect(workflow?.transitions).toContainEqual({
+      from: 'Active',
+      event: 'Fail',
+      to: 'Idle',
+    });
+  });
+
+  it('extracts nested Match.tags state and event transitions', () => {
+    const { machines } = analyzeStateMachines(effectIdiomsFixture);
+    const tagged = machines.find((m) => m.name === 'taggedTransition');
+    expect(tagged?.source).toBe('match');
+    expect(tagged?.transitions).toEqual([
+      { from: 'Idle', event: 'Start', to: 'Active' },
+      { from: 'Active', event: 'Stop', to: 'Closed' },
+      { from: 'Active', event: 'Fail', to: 'Idle' },
+    ]);
+  });
+
+  it('does not treat plain Match.tags variant dispatch as a state machine', () => {
+    const { machines } = analyzeStateMachines(effectIdiomsFixture);
+    expect(machines.some((m) => m.name === 'plainVariantDispatch')).toBe(false);
+  });
+});
+
+describe('declared alphabet', () => {
+  it('reads the alphabet from a satisfies-typed transition table', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const support = machines.find((m) => m.name === 'supportTransitions');
+    expect(support?.alphabetSource).toBe('tagged-union');
+    expect([...(support?.declaredStates ?? [])].sort()).toEqual([
+      'Answered',
+      'Human',
+      'Refund',
+      'Triage',
+    ]);
+    expect([...(support?.declaredEvents ?? [])].sort()).toEqual([
+      'AnswerRequested',
+      'EscalationRequested',
+      'RefundRequested',
+      'Resolved',
+    ]);
+  });
+
+  it('reads the alphabet from a Match transition function signature', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const doc = machines.find((m) => m.name === 'docTransition');
+    expect([...(doc?.declaredStates ?? [])].sort()).toEqual([
+      'Draft',
+      'Published',
+      'Review',
+    ]);
+    expect([...(doc?.declaredEvents ?? [])].sort()).toEqual([
+      'Approve',
+      'Reject',
+      'Submit',
+    ]);
+  });
+
+  it('classifies Schema.TaggedClass and TaggedRequest unions as schema alphabets', () => {
+    const { machines } = analyzeStateMachines(effectIdiomsFixture);
+    const workflow = machines.find((m) => m.name === 'workflowTransitions');
+    expect(workflow?.alphabetSource).toBe('schema');
+    expect([...(workflow?.declaredStates ?? [])].sort()).toEqual([
+      'Active',
+      'Closed',
+      'Idle',
+    ]);
+    expect([...(workflow?.declaredEvents ?? [])].sort()).toEqual([
+      'Fail',
+      'Start',
+      'Stop',
+    ]);
+  });
+
+  it('leaves the alphabet undefined when there is no type to read', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const gate = machines.find((m) => m.name === 'gateTransitions');
+    // gateTransitions uses `as const` with no `satisfies`, so no declared alphabet
+    expect(gate?.declaredStates).toBeUndefined();
+    expect(gate?.declaredEvents).toBeUndefined();
+  });
+});
+
+describe('renderers', () => {
+  it('renders a stateDiagram-v2', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const support = machines.find((m) => m.name === 'supportTransitions')!;
+    const chart = renderStatechartMermaid(support);
+    expect(chart).toContain('stateDiagram-v2');
+    expect(chart).toContain('[*] --> Triage');
+    expect(chart).toContain('Triage --> Refund: RefundRequested');
+    expect(chart).toContain('Answered --> [*]');
+  });
+
+  it('emits a valid XState createMachine config', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const doc = machines.find((m) => m.name === 'docTransition')!;
+    const config = renderXStateConfig(doc);
+    expect(config).toContain("import { createMachine } from 'xstate'");
+    expect(config).toContain("id: 'docTransition'");
+    expect(config).toContain("initial: 'Draft'");
+    expect(config).toContain("Draft: { on: { Submit: 'Review' } }");
+    expect(config).toContain("Published: { type: 'final' }");
+  });
+
+  it('escapes string literal state and event names in XState config', () => {
+    const source = `
+      import { Match } from 'effect';
+      type State = "Reader's Draft" | "Review";
+      type Event = "Submit's Ready";
+
+      export const copyTransition = (state: State, event: Event): State =>
+        Match.value([state, event] as const).pipe(
+          Match.when(["Reader's Draft", "Submit's Ready"], () => "Review" as const),
+          Match.orElse(() => state),
+        );
+    `;
+    const { machines } = analyzeStateMachines('inline.ts', source);
+    const machine = machines.find((m) => m.name === 'copyTransition')!;
+    const config = renderXStateConfig(machine);
+
+    // The emitted config must be syntactically valid TypeScript even when state
+    // or event names contain apostrophes.
+    const project = new Project({ useInMemoryFileSystem: true });
+    const sf = project.createSourceFile('machine.ts', config);
+    const syntacticErrors = project
+      .getProgram()
+      .getSyntacticDiagnostics(sf)
+      .map((d) => d.getMessageText());
+
+    expect(syntacticErrors).toEqual([]);
+    // sanity: the apostrophe state name made it through, properly escaped
+    expect(config).toContain("Reader\\'s Draft");
+  });
+
+  it('emits a guarded transition as an array (no duplicate event keys)', () => {
+    const { machines } = analyzeStateMachines(advancedFixture);
+    const job = machines.find((m) => m.name === 'jobTransition')!;
+    const config = renderXStateConfig(job);
+    expect(config).toContain(
+      `Running: { on: { Finish: [{ target: 'Done', guard: 'Math.random() > 0.5' }, { target: 'Failed' }], Error: 'Failed' } }`,
+    );
+    // never emit a duplicate object key
+    expect(config).not.toMatch(/Finish:.*Finish:/);
+  });
+
+  it('renders a self-contained SVG statechart', () => {
+    const { machines } = analyzeStateMachines(fixture);
+    const support = machines.find((m) => m.name === 'supportTransitions')!;
+    const svg = renderStatechartSVG(support);
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg).toContain('</svg>');
+    // event pill text and state labels are present
+    expect(svg).toContain('RefundRequested');
+    expect(svg).toContain('Triage');
+  });
+});

--- a/packages/effect-analyzer/src/state-machine.ts
+++ b/packages/effect-analyzer/src/state-machine.ts
@@ -1,0 +1,671 @@
+/**
+ * Finite State Machine Analysis
+ *
+ * Recognizes plain-Effect state machines (no XState) and extracts
+ * (fromState, event, toState) transition triples so they can be rendered
+ * as an XState-style statechart.
+ *
+ * Shapes detected:
+ *  A) Declarative transition table — a nested object literal:
+ *       { Triage: { RefundRequested: 'Refund', ... }, ... }
+ *  B) Match.when tuple function — Match.value([s._tag, e._tag]).pipe(
+ *       Match.when(['Draft', 'Submit'], () => ({ _tag: 'Review' })), ...)
+ *  C) Nested Match.tags dispatch — outer tags are states, inner tags are events.
+ *     Both expression-body and block-body (`{ return { _tag } }`) handlers
+ *     are supported; a handler with multiple distinct returned tags yields
+ *     one transition per target (best-effort guarded transitions).
+ * Initial state is taken from, in order: an `@initial <State>` annotation on
+ * the machine declaration, a sibling `initial`/`initialState`/`startState`
+ * declaration whose value is one of the machine's states, else the first
+ * reachable state.
+ */
+
+import { statSync } from 'node:fs';
+import { Node, Project, SyntaxKind, type ObjectLiteralExpression } from 'ts-morph';
+import type { SourceLocation } from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface StateTransition {
+  readonly from: string;
+  readonly event: string;
+  readonly to: string;
+  /** Guard condition text when the transition is conditional (best-effort). */
+  readonly guard?: string;
+}
+
+export interface StateMachine {
+  readonly name: string;
+  readonly source: 'transition-table' | 'match';
+  readonly initial: string | undefined;
+  /** States that appear in the extracted transitions. */
+  readonly states: readonly string[];
+  readonly transitions: readonly StateTransition[];
+  readonly location: SourceLocation | undefined;
+  /**
+   * The declared alphabet — the full set of states/events from the machine's
+   * types (a tagged union or a Schema-derived type). `undefined` when the type
+   * could not be resolved. Used to check the machine for completeness.
+   */
+  readonly declaredStates: readonly string[] | undefined;
+  readonly declaredEvents: readonly string[] | undefined;
+  readonly alphabetSource: 'schema' | 'tagged-union' | undefined;
+}
+
+export interface StateMachineAnalysis {
+  readonly machines: readonly StateMachine[];
+}
+
+// =============================================================================
+// AST helpers
+// =============================================================================
+
+/** Strip `as const`, `satisfies`, parentheses and `<T>` assertions. */
+function unwrap(node: Node): Node {
+  let cur = node;
+  for (;;) {
+    const k = cur.getKind();
+    if (
+      k === SyntaxKind.AsExpression ||
+      k === SyntaxKind.SatisfiesExpression ||
+      k === SyntaxKind.ParenthesizedExpression ||
+      k === SyntaxKind.TypeAssertionExpression
+    ) {
+      cur = (cur as unknown as { getExpression(): Node }).getExpression();
+      continue;
+    }
+    return cur;
+  }
+}
+
+/** Read a string-literal value (after unwrapping `as const`), or undefined. */
+function stringValue(node: Node | undefined): string | undefined {
+  if (!node) return undefined;
+  const u = unwrap(node);
+  if (Node.isStringLiteral(u)) return u.getLiteralValue();
+  if (Node.isNoSubstitutionTemplateLiteral(u)) return u.getLiteralText();
+  return undefined;
+}
+
+function propName(prop: Node): string | undefined {
+  if (!Node.isPropertyAssignment(prop)) return undefined;
+  const nameNode = prop.getNameNode();
+  if (Node.isStringLiteral(nameNode)) return nameNode.getLiteralValue();
+  if (Node.isIdentifier(nameNode)) return nameNode.getText();
+  return undefined;
+}
+
+/** Extract the `_tag` string literal from an object literal, if present. */
+function tagFromObject(obj: Node): string | undefined {
+  if (!Node.isObjectLiteralExpression(obj)) return undefined;
+  const tagProp = obj.getProperty('_tag');
+  if (!tagProp || !Node.isPropertyAssignment(tagProp)) return undefined;
+  return stringValue(tagProp.getInitializer());
+}
+
+function locOf(node: Node, filePath: string): SourceLocation {
+  const sf = node.getSourceFile();
+  const offset = node.getStart();
+  const { line, column } = sf.getLineAndColumnAtPos(offset);
+  return { filePath, line, column, offset };
+}
+
+function uniqueStates(transitions: readonly StateTransition[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of transitions) {
+    for (const s of [t.from, t.to]) {
+      if (!seen.has(s)) {
+        seen.add(s);
+        out.push(s);
+      }
+    }
+  }
+  return out;
+}
+
+// =============================================================================
+// Declared-alphabet extraction (via the type checker)
+//
+// The type checker resolves a hand-written tagged union and a Schema-derived
+// type (`Schema.Schema.Type<typeof X>`) to the same shape, so one path handles
+// both. We read `_tag` string-literal members off the resolved type.
+// =============================================================================
+
+type TsType = ReturnType<Node['getType']>;
+
+/** String-literal members of a (possibly union) type, e.g. `'a' | 'b'` → ['a','b']. */
+function stringLiteralsOfType(type: TsType): string[] {
+  const members = type.isUnion() ? type.getUnionTypes() : [type];
+  const out: string[] = [];
+  for (const m of members) {
+    const v = m.getLiteralValue();
+    if (typeof v === 'string' && !out.includes(v)) out.push(v);
+  }
+  return out;
+}
+
+/** `_tag` literals of each member of a tagged-union type. */
+function tagsOfUnion(type: TsType, at: Node): string[] {
+  const members = type.isUnion() ? type.getUnionTypes() : [type];
+  const out: string[] = [];
+  for (const m of members) {
+    const prop = m.getProperty('_tag');
+    if (!prop) continue;
+    const v = prop.getTypeAtLocation(at).getLiteralValue();
+    if (typeof v === 'string' && !out.includes(v)) out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Alphabet members of a type: `_tag` literals of a tagged union, or — for a
+ * `Schema.Literal('a','b')` / `type E = 'a' | 'b'` style — the string literals
+ * themselves.
+ */
+function alphabetMembers(type: TsType, at: Node): string[] {
+  const tags = tagsOfUnion(type, at);
+  return tags.length ? tags : stringLiteralsOfType(type);
+}
+
+/** Classify a named type as Schema-derived or a plain tagged union. */
+function classifyAlphabet(
+  typeName: string | undefined,
+  sf: ReturnType<Project['createSourceFile']>,
+): 'schema' | 'tagged-union' | undefined {
+  if (!typeName) return undefined;
+  const alias = sf.getTypeAlias(typeName);
+  if (!alias) return undefined;
+  const txt = alias.getTypeNode()?.getText() ?? '';
+  if (/\bSchema\b|typeof/.test(txt)) return 'schema';
+  const names = [...txt.matchAll(/\b[A-Z][A-Za-z0-9_$]*\b/g)].map((m) => m[0]);
+  if (
+    names.some((name) =>
+      sf.getClass(name)?.getExtends()?.getText().includes('Schema.'),
+    )
+  ) {
+    return 'schema';
+  }
+  return 'tagged-union';
+}
+
+/** Find the function node behind a machine declaration (arrow / fn expr / fn decl). */
+function functionOf(decl: Node): Node | undefined {
+  if (Node.isFunctionDeclaration(decl)) return decl;
+  if (Node.isVariableDeclaration(decl)) {
+    const init = decl.getInitializer();
+    if (init && (Node.isArrowFunction(init) || Node.isFunctionExpression(init))) {
+      return init;
+    }
+  }
+  return undefined;
+}
+
+interface Alphabet {
+  readonly states: readonly string[] | undefined;
+  readonly events: readonly string[] | undefined;
+  readonly source: 'schema' | 'tagged-union' | undefined;
+}
+
+const EMPTY_ALPHABET: Alphabet = {
+  states: undefined,
+  events: undefined,
+  source: undefined,
+};
+
+const analysisCache = new Map<
+  string,
+  { readonly mtimeMs: number; readonly analysis: StateMachineAnalysis }
+>();
+
+/** Alphabet for a `(state, event) => state` transition function (Shape B). */
+function alphabetFromFunction(
+  fn: Node,
+  sf: ReturnType<Project['createSourceFile']>,
+): Alphabet {
+  if (!Node.isArrowFunction(fn) && !Node.isFunctionExpression(fn) && !Node.isFunctionDeclaration(fn)) {
+    return EMPTY_ALPHABET;
+  }
+  const params = fn.getParameters();
+  const stateParam = params[0];
+  const eventParam = params[1];
+  if (!stateParam || !eventParam) return EMPTY_ALPHABET;
+  const states = alphabetMembers(stateParam.getType(), stateParam);
+  const events = alphabetMembers(eventParam.getType(), eventParam);
+  return {
+    states: states.length ? states : undefined,
+    events: events.length ? events : undefined,
+    source: classifyAlphabet(stateParam.getTypeNode()?.getText(), sf),
+  };
+}
+
+/** Alphabet for a `... satisfies Record<State['_tag'], Record<Event['_tag'], ...>>` table (Shape A). */
+function alphabetFromTable(
+  decl: Node,
+  sf: ReturnType<Project['createSourceFile']>,
+): Alphabet {
+  if (!Node.isVariableDeclaration(decl)) return EMPTY_ALPHABET;
+  const init = decl.getInitializer();
+  if (init?.getKind() !== SyntaxKind.SatisfiesExpression) {
+    return EMPTY_ALPHABET; // no `satisfies` ⇒ no declared alphabet
+  }
+  const typeNode = (
+    init as unknown as { getTypeNode(): Node | undefined }
+  ).getTypeNode();
+  if (!typeNode) return EMPTY_ALPHABET;
+
+  // Collect distinct `X['_tag']` indexed-access types in source order.
+  const groups: { name: string; tags: string[] }[] = [];
+  const seen = new Set<string>();
+  for (const ia of typeNode.getDescendantsOfKind(SyntaxKind.IndexedAccessType)) {
+    if (!ia.getIndexTypeNode().getText().includes('_tag')) continue;
+    const name = ia.getObjectTypeNode().getText();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    groups.push({ name, tags: stringLiteralsOfType(ia.getType()) });
+  }
+  const stateGroup = groups[0];
+  const eventGroup = groups[1];
+  return {
+    states: stateGroup?.tags.length ? stateGroup.tags : undefined,
+    events: eventGroup?.tags.length ? eventGroup.tags : undefined,
+    source: classifyAlphabet(stateGroup?.name, sf),
+  };
+}
+
+// =============================================================================
+// Initial-state detection
+// =============================================================================
+
+const INITIAL_NAMES = /^(initial|initialState|startState|start)$/i;
+
+/** Collect candidate initial-state tags from `initial`-ish declarations. */
+function collectInitialHints(sf: ReturnType<Project['createSourceFile']>): string[] {
+  const hints: string[] = [];
+  for (const decl of sf.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+    if (!INITIAL_NAMES.test(decl.getName())) continue;
+    const init = decl.getInitializer();
+    if (!init) continue;
+    const u = unwrap(init);
+    const direct = stringValue(u);
+    if (direct) {
+      hints.push(direct);
+      continue;
+    }
+    const tag = tagFromObject(u);
+    if (tag) hints.push(tag);
+  }
+  return hints;
+}
+
+/**
+ * All `@initial <State>` annotations in a declaration's leading trivia.
+ * Reads the raw leading comment text (more reliable than the JSDoc/comment-range
+ * APIs, which vary with preceding dividers). Returns every match so callers can
+ * pick the one that is actually a declared state.
+ */
+function annotatedInitials(decl: Node): string[] {
+  const stmt = Node.isVariableDeclaration(decl)
+    ? decl.getVariableStatement()
+    : decl;
+  if (!stmt) return [];
+  const leading = stmt
+    .getFullText()
+    .slice(0, stmt.getStart() - stmt.getFullStart());
+  return [...leading.matchAll(/@initial\s+([A-Za-z_$][\w$]*)/g)]
+    .map((m) => m[1])
+    .filter((x): x is string => x !== undefined);
+}
+
+function pickInitial(
+  states: readonly string[],
+  fallback: string | undefined,
+  decl: Node | undefined,
+  hints: readonly string[],
+): string | undefined {
+  const set = new Set(states);
+  for (const a of decl ? annotatedInitials(decl) : []) {
+    if (set.has(a)) return a;
+  }
+  const hinted = hints.find((h) => set.has(h));
+  if (hinted) return hinted;
+  return fallback;
+}
+
+// =============================================================================
+// Shape A: declarative transition table
+// =============================================================================
+
+function tableLeafTargets(
+  node: Node | undefined,
+): { to: string; guard?: string }[] {
+  if (!node) return [];
+  const leaf = unwrap(node);
+  const direct = stringValue(leaf);
+  if (direct) return [{ to: direct }];
+  if (Node.isObjectLiteralExpression(leaf)) {
+    const target =
+      stringValue(leaf.getProperty('target')?.asKind(SyntaxKind.PropertyAssignment)?.getInitializer()) ??
+      stringValue(leaf.getProperty('to')?.asKind(SyntaxKind.PropertyAssignment)?.getInitializer()) ??
+      tagFromObject(leaf);
+    if (!target) return [];
+    const guard = stringValue(
+      leaf.getProperty('guard')?.asKind(SyntaxKind.PropertyAssignment)?.getInitializer(),
+    );
+    return guard === undefined ? [{ to: target }] : [{ to: target, guard }];
+  }
+  if (Node.isArrayLiteralExpression(leaf)) {
+    return leaf
+      .getElements()
+      .flatMap((element) => tableLeafTargets(element));
+  }
+  return [];
+}
+
+function extractTable(
+  decl: Node,
+  filePath: string,
+  hints: readonly string[],
+  sf: ReturnType<Project['createSourceFile']>,
+): StateMachine | undefined {
+  if (!Node.isVariableDeclaration(decl)) return undefined;
+  const init = decl.getInitializer();
+  if (!init) return undefined;
+  const obj = unwrap(init);
+  if (!Node.isObjectLiteralExpression(obj)) return undefined;
+
+  const transitions: StateTransition[] = [];
+  const fromStates: string[] = [];
+
+  for (const prop of obj.getProperties()) {
+    if (!Node.isPropertyAssignment(prop)) return undefined; // not a clean table
+    const from = propName(prop);
+    if (from === undefined) return undefined;
+    const val = unwrap(prop.getInitializerOrThrow());
+    if (!Node.isObjectLiteralExpression(val)) return undefined; // every value must be an object
+    fromStates.push(from);
+    for (const inner of val.getProperties()) {
+      if (!Node.isPropertyAssignment(inner)) return undefined;
+      const event = propName(inner);
+      const targets = tableLeafTargets(inner.getInitializer());
+      if (event === undefined || targets.length === 0) return undefined;
+      for (const { to, guard } of targets) {
+        transitions.push(
+          guard === undefined ? { from, event, to } : { from, event, to, guard },
+        );
+      }
+    }
+  }
+
+  // FSM signal: at least one transition, and at least one target is itself a
+  // declared state — distinguishes a transition table from an arbitrary config.
+  if (transitions.length === 0) return undefined;
+  const fromSet = new Set(fromStates);
+  if (!transitions.some((t) => fromSet.has(t.to))) return undefined;
+
+  const states = uniqueStates(transitions);
+  const alphabet = alphabetFromTable(decl, sf);
+  return {
+    name: decl.getName(),
+    source: 'transition-table',
+    initial: pickInitial(states, fromStates[0], decl, hints),
+    states,
+    transitions,
+    location: locOf(decl.getNameNode(), filePath),
+    declaredStates: alphabet.states,
+    declaredEvents: alphabet.events,
+    alphabetSource: alphabet.source,
+  };
+}
+
+// =============================================================================
+// Shape B: Match.when tuple function
+// =============================================================================
+
+/** Target state of a handler return: `{ _tag: 'X' }` or a bare `'X'` literal. */
+function targetFromExpr(node: Node): string | undefined {
+  const u = unwrap(node);
+  if (Node.isObjectLiteralExpression(u)) return tagFromObject(u);
+  if (Node.isStringLiteral(u)) return u.getLiteralValue();
+  return undefined;
+}
+
+/** The guard condition for a `return` nested in an `if`, as source text. */
+function guardForReturn(ret: Node, handler: Node): string | undefined {
+  let cur: Node | undefined = ret.getParent();
+  while (cur && cur !== handler) {
+    if (Node.isIfStatement(cur)) {
+      const cond = cur.getExpression().getText();
+      const thenStmt = cur.getThenStatement();
+      const inThen =
+        ret.getStart() >= thenStmt.getStart() &&
+        ret.getEnd() <= thenStmt.getEnd();
+      return inThen ? cond : `!(${cond})`;
+    }
+    cur = cur.getParent();
+  }
+  return undefined;
+}
+
+/**
+ * Target states a handler can return, each with its guard condition (if any).
+ * More than one target ⇒ a guarded (conditional) transition.
+ */
+function returnedTransitions(
+  handler: Node | undefined,
+): { to: string; guard?: string }[] {
+  if (!handler) return [];
+  if (!Node.isArrowFunction(handler) && !Node.isFunctionExpression(handler)) {
+    return [];
+  }
+  const out: { to: string; guard?: string }[] = [];
+  const seen = new Set<string>();
+  const push = (to: string | undefined, guard?: string): void => {
+    if (!to) return;
+    const k = `${to}|${guard ?? ''}`;
+    if (seen.has(k)) return;
+    seen.add(k);
+    out.push(guard === undefined ? { to } : { to, guard });
+  };
+
+  const body = handler.getBody();
+  if (!Node.isBlock(body)) {
+    push(targetFromExpr(body)); // expression body
+    return out;
+  }
+  for (const ret of body.getDescendantsOfKind(SyntaxKind.ReturnStatement)) {
+    const re = ret.getExpression();
+    if (re) push(targetFromExpr(re), guardForReturn(ret, handler));
+  }
+  return out;
+}
+
+function matchTagsObject(call: Node): ObjectLiteralExpression | undefined {
+  if (!Node.isCallExpression(call)) return undefined;
+  const expr = call.getExpression();
+  if (!Node.isPropertyAccessExpression(expr)) return undefined;
+  if (expr.getExpression().getText() !== 'Match') return undefined;
+  const name = expr.getName();
+  if (name !== 'tags' && name !== 'tagsExhaustive') return undefined;
+  const [arg] = call.getArguments();
+  if (!arg) return undefined;
+  const obj = unwrap(arg);
+  return Node.isObjectLiteralExpression(obj) ? obj : undefined;
+}
+
+function functionInitializer(prop: Node): Node | undefined {
+  if (!Node.isPropertyAssignment(prop)) return undefined;
+  const init = prop.getInitializer();
+  if (!init) return undefined;
+  const u = unwrap(init);
+  return Node.isArrowFunction(u) || Node.isFunctionExpression(u) ? u : undefined;
+}
+
+function nestedTagsTransitions(call: Node): StateTransition[] {
+  const outerObj = matchTagsObject(call);
+  if (!outerObj) return [];
+  const transitions: StateTransition[] = [];
+  for (const stateProp of outerObj.getProperties()) {
+    const from = propName(stateProp);
+    const stateHandler = functionInitializer(stateProp);
+    if (!from || !stateHandler) continue;
+    for (const innerCall of stateHandler.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+      const innerObj = matchTagsObject(innerCall);
+      if (!innerObj) continue;
+      for (const eventProp of innerObj.getProperties()) {
+        const event = propName(eventProp);
+        const eventHandler = functionInitializer(eventProp);
+        if (!event || !eventHandler) continue;
+        for (const { to, guard } of returnedTransitions(eventHandler)) {
+          transitions.push(
+            guard === undefined ? { from, event, to } : { from, event, to, guard },
+          );
+        }
+      }
+    }
+  }
+  return transitions;
+}
+
+function ownerOf(
+  node: Node,
+): { readonly name: string; readonly decl: Node; readonly anchor: Node } | undefined {
+  let cur: Node | undefined = node.getParent();
+  while (cur) {
+    if (Node.isVariableDeclaration(cur)) {
+      return { name: cur.getName(), decl: cur, anchor: cur.getNameNode() };
+    }
+    if (Node.isFunctionDeclaration(cur)) {
+      const name = cur.getName();
+      if (name) return { name, decl: cur, anchor: cur.getNameNodeOrThrow() };
+    }
+    cur = cur.getParent();
+  }
+  return undefined;
+}
+
+function extractMatchMachines(
+  sf: ReturnType<Project['createSourceFile']>,
+  filePath: string,
+  hints: readonly string[],
+): StateMachine[] {
+  const groups = new Map<
+    string,
+    { transitions: StateTransition[]; decl: Node; anchor: Node }
+  >();
+
+  for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    const nestedTransitions = nestedTagsTransitions(call);
+    if (nestedTransitions.length > 0) {
+      const owner = ownerOf(call);
+      if (!owner) continue;
+      const group = groups.get(owner.name) ?? {
+        transitions: [],
+        decl: owner.decl,
+        anchor: owner.anchor,
+      };
+      group.transitions.push(...nestedTransitions);
+      groups.set(owner.name, group);
+      continue;
+    }
+
+    const expr = call.getExpression();
+    if (!Node.isPropertyAccessExpression(expr)) continue;
+    if (expr.getName() !== 'when') continue;
+    if (expr.getExpression().getText() !== 'Match') continue;
+
+    const [patternArg, handlerArg] = call.getArguments();
+    if (!patternArg || !handlerArg) continue;
+    const tuple = unwrap(patternArg);
+    if (!Node.isArrayLiteralExpression(tuple)) continue;
+    const els = tuple.getElements();
+    if (els.length !== 2) continue;
+    const from = stringValue(els[0]);
+    const event = stringValue(els[1]);
+    const tos = returnedTransitions(handlerArg);
+    if (from === undefined || event === undefined || tos.length === 0) continue;
+
+    const owner = ownerOf(call);
+    if (!owner) continue;
+    const group = groups.get(owner.name) ?? {
+      transitions: [],
+      decl: owner.decl,
+      anchor: owner.anchor,
+    };
+    for (const { to, guard } of tos) {
+      group.transitions.push(
+        guard === undefined ? { from, event, to } : { from, event, to, guard },
+      );
+    }
+    groups.set(owner.name, group);
+  }
+
+  const machines: StateMachine[] = [];
+  for (const [name, { transitions, decl, anchor }] of groups) {
+    if (transitions.length === 0) continue;
+    const states = uniqueStates(transitions);
+    const fn = functionOf(decl);
+    const alphabet = fn ? alphabetFromFunction(fn, sf) : EMPTY_ALPHABET;
+    machines.push({
+      name,
+      source: 'match',
+      initial: pickInitial(states, transitions[0]?.from, decl, hints),
+      states,
+      transitions,
+      location: locOf(anchor, filePath),
+      declaredStates: alphabet.states,
+      declaredEvents: alphabet.events,
+      alphabetSource: alphabet.source,
+    });
+  }
+  return machines;
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+export function analyzeStateMachines(
+  filePath: string,
+  source?: string,
+): StateMachineAnalysis {
+  const mtimeMs =
+    source === undefined
+      ? (() => {
+          try {
+            return statSync(filePath).mtimeMs;
+          } catch {
+            return undefined;
+          }
+        })()
+      : undefined;
+  // Only trust the cache when the mtime is known; a failed stat must re-analyze.
+  if (source === undefined && mtimeMs !== undefined) {
+    const cached = analysisCache.get(filePath);
+    if (cached && cached.mtimeMs === mtimeMs) return cached.analysis;
+  }
+  const project = new Project({ useInMemoryFileSystem: !!source });
+  const sf = source
+    ? project.createSourceFile(filePath, source, { overwrite: true })
+    : project.addSourceFileAtPath(filePath);
+
+  const hints = collectInitialHints(sf);
+  const machines: StateMachine[] = [];
+
+  // Shape A: scan top-level + exported variable declarations.
+  for (const decl of sf.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+    const machine = extractTable(decl, filePath, hints, sf);
+    if (machine) machines.push(machine);
+  }
+
+  // Shape B: Match.when tuple functions.
+  machines.push(...extractMatchMachines(sf, filePath, hints));
+
+  const analysis = { machines };
+  if (source === undefined && mtimeMs !== undefined) {
+    analysisCache.set(filePath, { mtimeMs, analysis });
+  }
+  return analysis;
+}

--- a/packages/effect-analyzer/state-machine-conventions.md
+++ b/packages/effect-analyzer/state-machine-conventions.md
@@ -1,0 +1,190 @@
+# Effect State Machine Conventions
+
+Write state machines as ordinary Effect and TypeScript. `effect-analyzer` reads
+these conventions and renders XState-style diagrams, exports a Stately config,
+and checks the machine for completeness. No XState runtime ends up in your code.
+
+## Quickstart
+
+Write a transition function over two tagged unions and mark the initial state:
+
+```ts
+import { Match } from 'effect'
+
+type State = { readonly _tag: 'Closed' } | { readonly _tag: 'Open' }
+type Event = { readonly _tag: 'Toggle' }
+
+/** @initial Closed */
+export const door = (state: State, event: Event): State =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['Closed', 'Toggle'], () => ({ _tag: 'Open' as const })),
+    Match.when(['Open', 'Toggle'], () => ({ _tag: 'Closed' as const })),
+    Match.orElse(() => state),
+  )
+```
+
+Run it with no flags — the default view surfaces any state machine in the file:
+
+```bash
+npx effect-analyze ./door.ts
+```
+
+For the full visualizer, ask for `statechart-html`. With no `-o` it writes
+`door.statechart.html` next to the input. Add `--open` to launch it:
+
+```bash
+npx effect-analyze ./door.ts --format statechart-html --open
+```
+
+That page carries the statechart, a coverage report, and an XState config you
+can paste into stately.ai/viz.
+
+## Contract
+
+A state machine is a deterministic function shaped like this:
+
+```ts
+type Transition = (state: State, event: Event) => State;
+```
+
+Use one of these alphabets:
+
+- Tagged unions: `{ readonly _tag: 'Draft' } | { readonly _tag: 'Review' }`
+- `Schema.TaggedClass` / `Schema.TaggedRequest` unions
+- `Schema.Schema.Type<typeof SomeTaggedUnion>`
+- Plain string-literal unions: `'Draft' | 'Review'`
+
+Mark the start with an `@initial <State>` comment on the declaration, or a
+sibling declaration named `initial`, `initialState`, `startState`, or `start`.
+
+## Supported Authoring Styles
+
+### Transition Table
+
+Use a nested object where outer keys are states and inner keys are events.
+Leaves may be strings, target objects, or guarded target arrays.
+
+```ts
+/** @initial Draft */
+export const transitions = {
+  Draft: {
+    Submit: 'Review',
+  },
+  Review: {
+    Approve: { target: 'Published', guard: 'canPublish' },
+    Reject: [{ target: 'Draft', guard: 'needsChanges' }],
+  },
+  Published: {},
+} as const satisfies Record<
+  State['_tag'],
+  Partial<Record<Event['_tag'], State['_tag'] | { readonly target: State['_tag']; readonly guard?: string }>>
+>;
+```
+
+A string leaf and a `{ target }` object mean the same thing. The `guard` string
+is a label: the analyzer prints it on the edge and in the exported config, but
+never runs it. Keep the real check in your own code.
+
+### Match.when
+
+Use a tuple pattern `[state, event]`. Return the next state as either a tagged
+object or a string literal.
+
+```ts
+/** @initial Draft */
+export const transition = (state: State, event: Event): State =>
+  Match.value([state._tag, event._tag] as const).pipe(
+    Match.when(['Draft', 'Submit'], () => ({ _tag: 'Review' as const })),
+    Match.when(['Review', 'Approve'], () => ({ _tag: 'Published' as const })),
+    Match.when(['Review', 'Reject'], () => ({ _tag: 'Draft' as const })),
+    Match.orElse(() => state),
+  );
+```
+
+When a handler returns different states under `if` branches, the analyzer emits
+one transition per target and labels each edge with the branch condition.
+
+For a string-literal alphabet, drop `._tag` and return the string:
+
+```ts
+Match.when(['Red', 'Tick'], () => 'Green' as const)
+```
+
+### Nested Match.tags
+
+Outer tags are source states; inner tags are events. The analyzer ignores a
+single-level `Match.tags`, reading it as ordinary variant dispatch.
+
+```ts
+export const transition = (state: State, event: Event): State =>
+  Match.value(state).pipe(
+    Match.tags({
+      Draft: () =>
+        Match.value(event).pipe(
+          Match.tags({
+            Submit: () => ({ _tag: 'Review' as const }),
+          }),
+        ),
+      Review: () =>
+        Match.value(event).pipe(
+          Match.tags({
+            Approve: () => ({ _tag: 'Published' as const }),
+            Reject: () => ({ _tag: 'Draft' as const }),
+          }),
+        ),
+      Published: () => state,
+    }),
+  );
+```
+
+## Tooling Outputs
+
+```bash
+npx effect-analyze ./workflow.ts --format statechart-html -o statechart.html
+npx effect-analyze ./workflow.ts --format xstate-config
+npx effect-analyze ./workflow.ts --format mermaid-statechart
+npx effect-analyze ./workflow.ts --format svg-statechart
+npx effect-analyze ./workflow.ts --format statechart-coverage
+```
+
+`statechart-html` is the local visualizer: SVG diagram, coverage report, and
+paste-ready XState config in one page. `xstate-config` is for Stately import.
+
+## Coverage Gate
+
+The analyzer compares extracted transitions with the declared state/event
+alphabet and reports:
+
+- Unhandled declared events
+- Unreachable states
+- Undeclared states or events used by transitions
+- Final states with no outgoing transition
+
+For CI:
+
+```bash
+npx effect-analyze ./src --format statechart-coverage
+npx effect-analyze ./src --format statechart-coverage --min-coverage 60
+npx effect-analyze ./src --format statechart-coverage --coverage-json
+```
+
+The command exits non-zero when warnings exist or a minimum coverage threshold
+is missed.
+
+## When detection fails
+
+A command that finds no machines lists the declarations that came close and why.
+A `Match.when` whose handler returns a computed value instead of a literal state
+reports `a Match.when handler does not return a literal next state`, with the
+file, line, and a fix. Each run also prints a header naming the machines it found
+and their state and event counts.
+
+## Non-Goals
+
+This is not an XState runtime clone. Keep application code as plain functions
+and data. Do not introduce actors, interpreters, services, nested states, or
+parallel-state semantics unless the project already has a clear Effect-native
+convention for them.
+
+Optional helpers should remain zero-runtime metadata/inference helpers. Add
+them only when repeated boilerplate appears in real user code.

--- a/packages/effect-analyzer/vitest.config.ts
+++ b/packages/effect-analyzer/vitest.config.ts
@@ -2,7 +2,12 @@ import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    maxWorkers: '50%',
+    // ts-morph project creation + type checking is CPU-heavy. At high
+    // parallelism the heaviest fixture-sweep tests starve and time out, so cap
+    // workers to keep each test fed. Pair with a generous timeout as a backstop.
+    maxWorkers: 2,
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     setupFiles: ['./vitest.setup.ts'],
     exclude: [
       ...configDefaults.exclude,


### PR DESCRIPTION
## Summary

Add state machine analysis to effect-analyzer. Detect plain-Effect state machines (declarative transition tables and `Match.when` transition functions) and render them as XState-style statecharts without an XState dependency.

## What's included

- **Detection**: extracts `(from, event, to)` transitions, handles block-body and guarded multi-target handlers, string-literal/`_tag` alphabets, and initial-state detection.
- **Renderers**: `mermaid-statechart` (stateDiagram-v2), `svg-statechart` (self-contained SVG), `statechart-html` (local visualizer, opens with `--open`), and `xstate-config` (`createMachine()` for stately.ai/viz).
- **Schema-aware coverage**: reads the declared alphabet from tagged unions or Schema-derived types, reports unhandled events, unreachable states, and undeclared symbols. Adds a `--min-coverage` threshold, `--coverage-json`, and a non-zero CI exit on warnings.
- **Near-miss diagnostics**: when a command finds no machines, explain why each candidate was rejected, with `file:line` and a fix.
- **DX defaults**: the no-flag view auto-detects and renders any machine in a file; HTML formats write `<name>.statechart.html` when no `-o` is given.
- **Tooling**: harden the analysis cache against stale mtime reads, cap vitest workers at 2 for a stable suite, ship the conventions guide at the package root.

## Testing

`pnpm quality` passes: build, lint, type-check, and 948/948 tests green.

## Release

Includes a `minor` changeset for `effect-analyzer` (0.2.0 → 0.3.0).
