### PR TITLE
chore: sync package versions with published registry state

### DIFF
--- a/packages/effect-analyzer/package.json
+++ b/packages/effect-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-analyzer",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "type": "module",
   "description": "Static analysis for Effect-TS code. Analyze Effect code to extract structure, calculate complexity, and generate visualizations.",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Syncs each published package's `version` field on `main` up to the version currently published on npm.

**Why:** during the GitLab-interim period, supersede/clean versions were published to npm, but those version bumps never landed on GitHub `main`. As a result `main` is *behind* the registry, so the next `changesets` release would recompute versions that are **already published** → publish collisions. This realigns `main` with the registry so releases compute correctly.

**Scope:** only the `version` field of published (non-private) packages is changed — **no dependency, source, or changeset changes**. Dependency updates already merged on GitHub (e.g. dependabot) are preserved. Internal deps use the `workspace:` protocol, so no internal-dep rewrites are needed.

Validated by CI (`build-and-test` runs the frozen install).
