### PR TITLE
fix(ci): skip changeset guard on auto-generated release PR

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   changeset:
+    # Skip on the auto-generated release PR, which consumes changesets and
+    # bumps versions — `changeset status` would always fail there.
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `Changeset` workflow runs `changeset status` on every PR into `main` to enforce that package changes ship with a changeset. But the auto-generated release PR (`changeset-release/main`, "chore: release packages") **consumes** the changeset files and bumps versions — so the check always sees "packages changed but no changesets" and fails.

This is why the release PR into main fails every time (e.g. #157), even though feature PRs pass.

## Fix

Skip the `changeset` job on the `changeset-release/main` branch, while keeping it enforced on all real feature PRs:

```yaml
if: github.head_ref != 'changeset-release/main'
```

## Notes
- `github.head_ref` is used only in an `if:` expression (no shell interpolation), so no injection risk.
- Once merged, the existing #157 won't auto-fix retroactively — push an empty commit / reopen it to re-run, or merge it directly since `build-and-test` already passed.