### PR TITLE
feat: sharpen coverage-audit unknown-node diagnostics

### DIFF
--- a/.changeset/coverage-audit-dx.md
+++ b/.changeset/coverage-audit-dx.md
@@ -1,0 +1,14 @@
+---
+'effect-analyzer': minor
+---
+
+Sharpen coverage-audit unknown-node diagnostics.
+
+- The "Located unknown nodes" list now reports truncation as
+  `Located unknown nodes (showing 10 of N):` instead of silently capping at 10.
+- Unresolved nodes are now classified by kind — non-Effect object literal,
+  predicate/boolean expression, unrecognized constructor, unresolved
+  property access or identifier, non-Effect conditional/function expression —
+  so `Top unknown node reasons` is an actionable histogram rather than one
+  opaque `Could not determine effect type` bucket. That default reason still
+  applies to genuinely unclassifiable node kinds.

--- a/packages/effect-analyzer/src/effect-analysis.ts
+++ b/packages/effect-analyzer/src/effect-analysis.ts
@@ -671,11 +671,37 @@ export const analyzeEffectExpression = (
       }
     }
 
-    // Default: unknown
+    // Default: unknown. Classify by node kind so the audit's "unknown node
+    // reasons" histogram is actionable instead of one opaque bucket. Most of
+    // these are non-Effect sub-expressions the walker reached in a position
+    // that isn't an Effect program (option objects, predicates, service impls).
+    const unknownReason = ((): string => {
+      switch (node.getKind()) {
+        case SyntaxKind.ObjectLiteralExpression:
+          return 'Non-Effect object literal (e.g. service impl or options argument)';
+        case SyntaxKind.BinaryExpression:
+        case SyntaxKind.PrefixUnaryExpression:
+          return 'Non-Effect predicate or boolean expression';
+        case SyntaxKind.NewExpression:
+          return 'Unrecognized constructor (not an error-like type)';
+        case SyntaxKind.PropertyAccessExpression:
+        case SyntaxKind.ElementAccessExpression:
+          return 'Unresolved property access (not tied back to an Effect)';
+        case SyntaxKind.Identifier:
+          return 'Unresolved identifier (not tied back to an Effect)';
+        case SyntaxKind.ConditionalExpression:
+          return 'Non-Effect conditional expression';
+        case SyntaxKind.ArrowFunction:
+        case SyntaxKind.FunctionExpression:
+          return 'Non-Effect function expression';
+        default:
+          return 'Could not determine effect type';
+      }
+    })();
     const unknownNode: StaticUnknownNode = {
       id: generateId(),
       type: 'unknown',
-      reason: 'Could not determine effect type',
+      reason: unknownReason,
       sourceCode: node.getText().slice(0, 100),
       location: extractLocation(node, filePath, opts.includeLocations ?? false),
     };

--- a/packages/effect-analyzer/src/output/coverage-report.test.ts
+++ b/packages/effect-analyzer/src/output/coverage-report.test.ts
@@ -65,6 +65,41 @@ describe('coverage report', () => {
     expect(output).not.toContain('/repo/src/index.ts');
   });
 
+  it('flags truncation when more unknown nodes exist than are listed', () => {
+    const findings = Array.from({ length: 14 }, (_, index) => ({
+      kind: 'unknown-node' as const,
+      nodeId: `n${String(index)}`,
+      message: 'unresolved',
+      suggestion: 'extract',
+      reason: 'unresolved',
+      location: { filePath: `/repo/src/f${String(index)}.ts`, line: index + 1, column: 1 },
+    }));
+    const output = renderCoverageReport(
+      { ...audit, fidelityFindings: findings },
+      { mode: 'human', root: '/repo/src', showTopUnknown: true },
+    );
+
+    expect(output).toContain('Located unknown nodes (showing 10 of 14):');
+  });
+
+  it('omits the truncation note when every unknown node is listed', () => {
+    const findings = Array.from({ length: 3 }, (_, index) => ({
+      kind: 'unknown-node' as const,
+      nodeId: `n${String(index)}`,
+      message: 'unresolved',
+      suggestion: 'extract',
+      reason: 'unresolved',
+      location: { filePath: `/repo/src/f${String(index)}.ts`, line: index + 1, column: 1 },
+    }));
+    const output = renderCoverageReport(
+      { ...audit, fidelityFindings: findings },
+      { mode: 'human', root: '/repo/src', showTopUnknown: true },
+    );
+
+    expect(output).toContain('Located unknown nodes:');
+    expect(output).not.toContain('showing');
+  });
+
   it('includes the typed policy decision in JSON output', () => {
     const output = renderCoverageReport(audit, {
       mode: 'json',

--- a/packages/effect-analyzer/src/output/coverage-report.ts
+++ b/packages/effect-analyzer/src/output/coverage-report.ts
@@ -104,11 +104,16 @@ const renderHuman = (
   }
 
   if (options.showTopUnknown) {
-    const findings = audit.fidelityFindings
-      .filter((finding) => finding.kind === 'unknown-node')
-      .slice(0, 10);
+    const unknownNodes = audit.fidelityFindings.filter(
+      (finding) => finding.kind === 'unknown-node',
+    );
+    const findings = unknownNodes.slice(0, 10);
     if (findings.length > 0) {
-      lines.push('', 'Located unknown nodes:');
+      const header =
+        findings.length < unknownNodes.length
+          ? `Located unknown nodes (showing ${String(findings.length)} of ${String(unknownNodes.length)}):`
+          : 'Located unknown nodes:';
+      lines.push('', header);
       for (const finding of findings) {
         const location = finding.location
           ? `${finding.location.filePath}:${String(finding.location.line)}:${String(finding.location.column)}`

--- a/packages/effect-analyzer/src/unknown-node-reasons.test.ts
+++ b/packages/effect-analyzer/src/unknown-node-reasons.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { Effect, Option } from 'effect';
+import { analyze } from './analyze';
+import { getStaticChildren, isStaticUnknownNode } from './types';
+import type { StaticFlowNode } from './types';
+
+const collectUnknownReasons = (roots: readonly StaticFlowNode[]): string[] => {
+  const stack: StaticFlowNode[] = [...roots];
+  const reasons: string[] = [];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    if (isStaticUnknownNode(node)) reasons.push(node.reason);
+    stack.push(...Option.getOrElse(getStaticChildren(node), () => [] as readonly StaticFlowNode[]));
+  }
+  return reasons;
+};
+
+describe('unknown node reasons', () => {
+  it('classifies a non-Effect object literal argument instead of the opaque default', async () => {
+    const programs = await Effect.runPromise(
+      analyze
+        .source(`
+          import { Context, Effect, Layer } from "effect";
+          class Store extends Context.Tag("Store")<Store, { get: () => Effect.Effect<number> }>() {}
+          export const StoreLive = Layer.succeed(Store, {
+            get: () => Effect.succeed(1),
+          });
+        `)
+        .all(),
+    );
+
+    const reasons = programs.flatMap((ir) => collectUnknownReasons([ir.root]));
+
+    expect(reasons).toContain('Non-Effect object literal (e.g. service impl or options argument)');
+    expect(reasons).not.toContain('Could not determine effect type');
+  });
+});


### PR DESCRIPTION
Sharpens the coverage-audit unknown-node output on two fronts.

## Changes

- **Kind-specific unknown reasons.** The classifier's fall-through dumped every unresolved node into one opaque `Could not determine effect type` bucket, making `Top unknown node reasons` a single useless line. It now classifies by node kind — non-Effect object literal, predicate/boolean expression, unrecognized constructor, unresolved property access/identifier, non-Effect conditional/function expression. The default reason is retained for genuinely unclassifiable kinds.
- **No silent truncation.** The "Located unknown nodes" list capped at 10 with no note; it now reports `Located unknown nodes (showing 10 of N):`, matching the existing suspicious-zeros pattern.

## Impact

On a sample corpus the histogram went from `19 — Could not determine effect type` to:

```
12  Non-Effect object literal (e.g. service impl or options argument)
 4  Non-Effect predicate or boolean expression
 2  Non-Effect conditional expression
 1  Unrecognized constructor (not an error-like type)
```

This immediately surfaces that most "unknowns" are non-Effect sub-expressions the walker reaches in argument position (`Layer.succeed` impls, `Effect.retry` options) — groundwork for a follow-up that suppresses those false positives.

## Tests

- `unknown-node-reasons.test.ts` — asserts an object-literal argument classifies with the specific reason, not the default.
- `coverage-report.test.ts` — truncated and non-truncated header cases.
- Full suite: 1010 pass, typecheck clean, lint 0 errors.
- Changeset: `minor`.