### PR TITLE
docs: position analyzer as a guardrail for coding agents

### DIFF
--- a/.changeset/agent-guardrails-docs.md
+++ b/.changeset/agent-guardrails-docs.md
@@ -1,0 +1,19 @@
+---
+'effect-analyzer': patch
+---
+
+Document the analyzer as a guardrail for coding agents.
+
+The README and the docs now lead with the check that no expression-level tool covers:
+a program's shape (what it requires, what it can fail with, how it retries) changing in
+a way that still compiles, still passes `oxlint`, and still satisfies the official
+`@effect/tsgo` diagnostics.
+
+- New **Guardrails for Coding Agents** page walking through `--agent-report` for the
+  backlog, `--lint-source --baseline --fail-on-new` for the gate, and `--diff` for
+  review, with a GitHub Actions job.
+- README gains the same three commands as a section, and the introduction names coding
+  agents as consumers of the output.
+- Every command and output sample in the new docs was run against the committed
+  fixtures first. `--diff` is documented as always exiting `0`, since it reports rather
+  than gates.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -51,6 +51,7 @@ export default defineConfig({
             { label: 'Introduction', slug: 'introduction' },
             { label: 'Installation', slug: 'installation' },
             { label: 'Quick Start', slug: 'quick-start' },
+            { label: 'Guardrails for Coding Agents', slug: 'agent-guardrails' },
           ],
         },
         {

--- a/apps/docs/src/content/docs/agent-guardrails.mdx
+++ b/apps/docs/src/content/docs/agent-guardrails.mdx
@@ -1,0 +1,150 @@
+---
+title: Guardrails for Coding Agents
+description: Wire effect-analyzer into the generate-check loop so your agent gets a failure it can read, and you get a diagram you can review.
+sidebar:
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+An agent edits an Effect program and widens its error channel from a tagged error to
+`Error`. TypeScript compiles it, `oxlint` passes, and the PR reads as a small change. The
+error channel is a property of the whole program, so a check that looks at one expression
+at a time has nothing to complain about.
+
+## Where this sits
+
+The official Effect diagnostics from `@effect/tsgo` cover the expression scope. They
+report an unused floating effect, or an `R` that still needs `UserRepository`, in a
+sentence the agent can act on. Turn them on. This page covers the layer above: what a
+program requires, what it can fail with, how it retries, and which services it reaches.
+
+<Aside type="tip">
+Run both. `--tsgo` merges the official type-aware Effect diagnostics into the same
+report as the analyzer's AST checks: `effect-analyze ./src --lint-source --tsgo=./tsconfig.json`.
+</Aside>
+
+## 1. Hand the agent a prioritized backlog
+
+```bash
+npx effect-analyze ./src --agent-report
+```
+
+```text
+Agent Report Summary
+====================
+Files: 52 | Programs: 345 | Unknown: 0.0%
+Lint: 0 errors, 37 warnings, 111 infos
+Error channel: 0 | Service health: 4 | Performance: 0 | Coupling: 0
+Total improvements: 36
+
+  P1 (Important): 5
+  P2 (Recommended): 31
+
+Top improvements:
+  [P1] Replace throw new Error with Effect.fail(tagged error) (3x, medium)
+  [P1] Use Ref or Atomic for shared state in concurrent code (2x, medium)
+  [P1] Use Effect.suspend or flatMap instead of sync returning Effect (1x, low)
+```
+
+Each entry carries a file and line, a suggestion, and an effort estimate, so an agent
+picks up the top item and works down instead of guessing at priorities. Point your agent
+at the markdown report, or parse the JSON.
+
+Add `--improve` to apply the fixes the analyzer makes on its own, and
+`--improve-dry-run` to read them first. See [Improve Mode & Agent
+Report](/effect-analyzer/project/improve/).
+
+## 2. Gate the build on new findings
+
+Record a baseline once, on `main`:
+
+```bash
+npx effect-analyze ./src --lint-source -o .cache/effect-baseline.json
+```
+
+Check every branch against it:
+
+```bash
+npx effect-analyze ./src --lint-source --baseline .cache/effect-baseline.json --fail-on-new
+```
+
+```json
+"baseline": {
+  "new": 0,
+  "resolved": 0,
+  "unchanged": 148
+}
+```
+
+The analyzer fingerprints each finding, so moving code between files does not trip the
+gate. It exits `1` when a finding appears that your baseline does not contain, and your
+agent can read that failure and regenerate against it rather than waiting for you to
+repeat the same correction. Findings your team fixes drop out of the report, so the
+baseline shrinks as the codebase improves.
+
+See the [Source Linter](/effect-analyzer/project/source-linter/) for the rule list and
+SARIF output.
+
+## 3. Show the reviewer what moved
+
+```bash
+npx effect-analyze HEAD:src/transfer.ts src/transfer.ts --diff
+```
+
+```text
+# Effect Program Diff: sendMoney → sendMoney
+
+| Metric | Count |
+|--------|-------|
+| Added | 6 |
+| Renamed | 1 |
+| Unchanged | 7 |
+| Structural changes | 2 |
+
++ **FraudScreening** (added)
++ **fraud.screen** (added)
++ **notifications.sendConfirmation** (added)
+
+## Structural Changes
+- + pipe block added
+- + retry block added
+```
+
+The text diff for that change reports 45 added lines and leaves you to work out what they
+do. The semantic diff names the services that arrived and the retry block that wrapped
+the transfer.
+
+`--diff` reports and always exits `0`. Post it as a PR comment for a human, or pipe it
+back to an agent that needs to know what its last edit did. Use `--format json` for
+machine consumption, `--format mermaid` for a diagram, and `--regression` to flag
+removed programs.
+
+For gates that fail a build, use `--fail-on-new` above, `--assert-diagram-fidelity`, the
+[audit policy flags](/effect-analyzer/project/coverage-audit/), or
+`--format statechart-coverage --min-coverage`.
+
+See [Semantic Diff](/effect-analyzer/project/diff/) and [What a text diff
+misses](/effect-analyzer/case-studies/review-scenarios/).
+
+## Putting it in CI
+
+```yaml
+- run: npx effect-analyze ./src --lint-source --baseline .cache/effect-baseline.json --fail-on-new
+- run: npx effect-analyze ./src --coverage-audit --quiet --max-audit-failed-files 0
+- if: always()
+  run: |
+    npx effect-analyze "origin/main:src/transfer.ts" src/transfer.ts --diff \
+      >> "$GITHUB_STEP_SUMMARY"
+```
+
+The first two steps fail the build and give your agent something to fix. The third runs
+either way and puts the shape change in the job summary, where you read it before
+approving.
+
+## What this does not do
+
+The analyzer reads source. It sees the retry policy you wrote, not how often that policy
+fired last night, and it cannot tell you which of the paths in a diagram production
+traffic reaches. Pass OpenTelemetry spans to `renderMermaidWithRuntimeTrace` to overlay a
+real trace onto a static diagram. Your observability stack still owns the rest.

--- a/apps/docs/src/content/docs/introduction.mdx
+++ b/apps/docs/src/content/docs/introduction.mdx
@@ -7,11 +7,11 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-**effect-analyzer** is a static analysis toolkit for [Effect](https://effect.website/) programs. It parses your TypeScript source code using [ts-morph](https://ts-morph.com/), extracts a typed **intermediate representation** (IR) of every Effect program it finds, and renders that IR into diagrams, metrics, reports, and structured data - all without executing your code.
+**effect-analyzer** is a static analysis toolkit for [Effect](https://effect.website/) programs. It parses your TypeScript source with [ts-morph](https://ts-morph.com/), extracts a typed **intermediate representation** (IR) of every Effect program it finds, and renders that IR into diagrams, metrics, reports, and structured data. Your code never runs.
 
-Think of it as a compiler front-end for Effect workflows. Where a compiler turns source into machine code, effect-analyzer turns source into understanding.
+A compiler front-end reads source and hands the compiler a structure to work on. This does the same for Effect workflows, then hands the structure to you and to your tooling.
 
-The fastest way to see that value is not the CLI output. It is the [live browser playground](/effect-analyzer/playground/) and the [interactive HTML viewer](/effect-analyzer/reference/html-viewer/). Those are the strongest product demos because they let people see the structure immediately and share it with others.
+Your CI can compare today's IR against the one you approved last week and fail the build when a program's shape moves, which gives a coding agent a failure it can read and act on. See [Guardrails for Coding Agents](/effect-analyzer/agent-guardrails/). You can also look at the structure yourself: the [live browser playground](/effect-analyzer/playground/) and the [interactive HTML viewer](/effect-analyzer/reference/html-viewer/) put the services, error paths, and concurrency of a function on one page you can share.
 
 ## What It Detects
 
@@ -45,6 +45,7 @@ Because the IR is a plain data structure, you can also consume it directly in yo
 ## Who It Is For
 
 - **Developers** exploring unfamiliar Effect codebases or reviewing pull requests
+- **Coding agents** that need a machine-readable failure to regenerate against, and a backlog to work down
 - **Teams** generating living documentation for complex workflows
 - **CI/CD pipelines** tracking complexity regressions and structural changes over time
 - **Tooling authors** building custom analysis, linting, or visualization on top of the structured IR

--- a/packages/effect-analyzer/README.md
+++ b/packages/effect-analyzer/README.md
@@ -1,14 +1,14 @@
 # effect-analyzer
 
-Static analysis for [Effect](https://effect.website/) programs. Visualize service dependencies, error channels, concurrency, and control flow as Mermaid diagrams - without running your code.
+Static analysis for [Effect](https://effect.website/) programs. It reads the shape of a program (services, error channel, retries, concurrency), reports when that shape changes, and draws it as Mermaid diagrams. Your code never runs.
 
 > **[Documentation](https://jagreehal.github.io/effect-analyzer/)** · **[Getting Started](https://jagreehal.github.io/effect-analyzer/quick-start/)** · **[Playground](https://jagreehal.github.io/effect-analyzer/playground/)** · **[CLI Reference](https://jagreehal.github.io/effect-analyzer/reference/cli/)** · **[API Reference](https://jagreehal.github.io/effect-analyzer/reference/api/)**
 
 ## Why
 
-Effect programs are powerful, but their structure - service dependencies, error topology, concurrency patterns - is hard to see in source. effect-analyzer parses your code with [ts-morph](https://ts-morph.com/) and the TypeScript type checker, then produces semantic diagrams and structured analysis. No runtime, no instrumentation.
+An agent edits an Effect program and widens its error channel from a tagged error to `Error`. TypeScript compiles it, `oxlint` passes, and the PR reads as a small change. The error channel is a property of the whole program, so a check that looks at one expression at a time has nothing to complain about.
 
-Use it for **code review**, **onboarding**, **architecture docs**, and **CI** to catch regressions in program shape.
+effect-analyzer parses your source with [ts-morph](https://ts-morph.com/) and the TypeScript type checker, builds a typed IR of every program it finds, and compares that IR against the version you approved last. Your agent consumes the JSON and the prioritized backlog. You read the diagram before merging.
 
 ## Install
 
@@ -43,6 +43,83 @@ npx effect-analyze ./src --coverage-audit --quiet \
   --max-audit-failed-files 0 \
   --max-audit-suspicious-zeros 0 \
   --min-audit-source-resolution 98
+```
+
+## Guardrails for Coding Agents
+
+Three commands cover the generate-check loop: one gives the agent a backlog to work
+from, one blocks new lint findings at the gate, and one puts the shape change in front
+of a reviewer. The full walkthrough is in
+[Guardrails for Coding Agents](https://jagreehal.github.io/effect-analyzer/agent-guardrails/).
+
+### 1. Hand the agent a prioritized backlog
+
+```bash
+npx effect-analyze ./src --agent-report
+```
+
+The report merges lint findings, error channel analysis, service health, performance
+anti-patterns, and coupling into one P0-P3 list. Each entry carries a file and line, a
+suggestion, and an effort estimate, so an agent picks up the top item and works down
+instead of guessing at priorities. Add `--improve` to apply the fixes the analyzer makes
+on its own, or `--improve-dry-run` to read them first.
+
+### 2. Gate the build on new findings
+
+Record a baseline on `main`:
+
+```bash
+npx effect-analyze ./src --lint-source -o .cache/effect-baseline.json
+```
+
+Then check every branch against it:
+
+```bash
+npx effect-analyze ./src --lint-source --baseline .cache/effect-baseline.json --fail-on-new
+```
+
+The analyzer fingerprints each finding, so moving code between files does not trip the
+gate. It exits `1` when a finding appears that your baseline does not contain, and your
+agent can read that failure and regenerate against it. Findings your team fixes drop out
+of the report, so the baseline shrinks as the codebase improves.
+
+### 3. Show the reviewer what moved
+
+```bash
+npx effect-analyze HEAD:src/transfer.ts src/transfer.ts --diff
+```
+
+```
+# Effect Program Diff: sendMoney → sendMoney
+
+| Metric | Count |
+|--------|-------|
+| Added | 6 |
+| Renamed | 1 |
+| Unchanged | 7 |
+| Structural changes | 2 |
+
++ **FraudScreening** (added)
++ **fraud.screen** (added)
+
+## Structural Changes
+- + pipe block added
+- + retry block added
+```
+
+`--diff` reports and always exits `0`. Pipe it into a PR comment for a human, or into
+an agent that needs to know what its last edit did. Use `--format json` for machine
+consumption, `--format mermaid` for a diagram, and `--regression` to flag removed
+programs. For gating, reach for `--fail-on-new` above, `--assert-diagram-fidelity`,
+or the [audit policy flags](#coverage-audit).
+
+### In GitHub Actions
+
+```yaml
+- run: npx effect-analyze ./src --lint-source --baseline .cache/effect-baseline.json --fail-on-new
+- run: npx effect-analyze ./src --coverage-audit --quiet --max-audit-failed-files 0
+- if: always()
+  run: npx effect-analyze "origin/main:src/transfer.ts" src/transfer.ts --diff >> "$GITHUB_STEP_SUMMARY"
 ```
 
 ## What You Get


### PR DESCRIPTION
## What

The README and docs currently lead with diagrams, which reads as documentation generation. This leads with the check instead: a program's shape (what it requires, what it can fail with, how it retries) changing in a way that still compiles, still passes `oxlint`, and still satisfies the official `@effect/tsgo` diagnostics. Nothing at the expression level catches that, because no single expression is wrong.

Diagrams stay, repositioned as the review surface rather than the product.

## Changes

- New **Guardrails for Coding Agents** page, added to the Getting Started sidebar. Walks through `--agent-report` for the backlog, `--lint-source --baseline --fail-on-new` for the gate, and `--diff` for review, with a GitHub Actions job wiring the three together.
- README gains the same three commands as a section, plus a rewritten headline and Why.
- Introduction reworked; coding agents named as consumers of the output.
- Patch changeset. `README.md` is in the package `files` array, so the published tarball changes and npm should get the new copy.

## Verified

Every command and every output sample was run against the committed fixtures before being documented:

| Command | Result |
|---|---|
| `--agent-report` | 36 improvements, P1/P2 counts as quoted |
| `--lint-source -o` then `--baseline --fail-on-new` | exit 0, 148 unchanged |
| same, with a baseline missing findings | exit 1 |
| `--diff` with `HEAD:` and `main:` refs | the sendMoney diff shown is real output |
| `--coverage-audit --quiet --max-audit-failed-files 0` | PASS, exit 0 |

`pnpm build` in `apps/docs` passes, the new page renders, and the sidebar link resolves.

## Note

`--diff` always exits `0`. It reports, it does not gate. Both pages say so and point at `--fail-on-new` for the actual gate. Worth deciding separately whether a `--fail-on-structural-change` flag is wanted; this PR documents the behaviour as it stands.