### PR TITLE
fix(docs): unstick the playground, which shipped an empty analyzer worker

### DIFF
--- a/.changeset/playground-worker-empty-chunk.md
+++ b/.changeset/playground-worker-empty-chunk.md
@@ -1,0 +1,30 @@
+---
+'effect-analyzer': patch
+---
+
+Stop `output/html.ts` from splicing a regex across template-literal boundaries,
+which made rolldown emit an empty chunk.
+
+To embed a literal `${` in the generated viewer script, the source closed the
+template literal and concatenated:
+
+```
+q.replace(/[.*+?^$` + `{}()|\\[\\]\\\\]/g, '\\\\$` + `&')
+```
+
+Bundling that through rolldown — Vite 8's bundler — produces a **zero-byte**
+chunk for whatever entry pulls in `renderInteractiveHTML`. No error, no warning:
+the build succeeds and the output is empty. Escaping the dollar as `\${` keeps
+the template intact and bundles normally. The second splice was never needed,
+because `$&` is not `${`.
+
+The rendered HTML is byte-identical before and after, so this changes nothing
+about the viewer — it only makes the module survive a rolldown-based bundler.
+Anyone bundling `renderInteractiveHTML` with Vite 8 would otherwise get an entry
+that silently does nothing.
+
+This is what took down the docs playground, whose analysis runs in a module
+worker: an empty worker chunk still serves as `200 application/javascript`, and
+an empty module is a valid module, so it loads without firing `error`, registers
+no `message` listener, and never replies. The page waited on "Analyzing in
+worker..." indefinitely.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "generate:transfer-observability": "pnpm --dir ../../packages/effect-analyzer build && node ./scripts/generate-transfer-observability.mjs",
     "generate:review-scenarios": "pnpm --dir ../../packages/effect-analyzer build && node ./scripts/generate-review-scenarios.mjs",
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node ./scripts/check-playground-worker.mjs",
     "preview": "astro preview",
     "clean": "rm -rf dist .astro"
   },

--- a/apps/docs/scripts/check-playground-worker.mjs
+++ b/apps/docs/scripts/check-playground-worker.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * The playground runs its analysis in a module worker. A bundler that emits an
+ * empty worker chunk produces no error anywhere: the file still serves as 200
+ * `application/javascript`, an empty module is a *valid* module, so it loads
+ * without firing `error` — it just never registers a `message` listener and
+ * never replies. The page sits on "Analyzing in worker..." forever.
+ *
+ * That is exactly what shipped: rolldown silently emitted a 0-byte chunk when
+ * `output/html.ts` spliced a regex across template-literal boundaries. Nothing
+ * in the build, the types, or the tests noticed.
+ *
+ * So: assert after every build that the worker chunk exists and actually
+ * contains the listener it is built around.
+ */
+
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distAstro = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', '_astro');
+
+const entries = await readdir(distAstro).catch(() => {
+  throw new Error(`No build output at ${distAstro} — run the docs build first.`);
+});
+
+const workers = entries.filter((name) => /^playground-worker-.*\.js$/.test(name));
+if (workers.length === 0) {
+  throw new Error('No playground-worker chunk was emitted; the playground cannot run.');
+}
+
+for (const worker of workers) {
+  const source = await readFile(join(distAstro, worker), 'utf8');
+  if (source.trim() === '') {
+    throw new Error(
+      `${worker} is empty. An empty module worker loads without error and never ` +
+        'replies, so the playground hangs on "Analyzing in worker...". This is ' +
+        'usually a bundler tree-shaking or parse failure in the worker import graph.',
+    );
+  }
+  if (!source.includes('addEventListener')) {
+    throw new Error(
+      `${worker} contains no addEventListener call, so it can never answer the ` +
+        'page. The worker entry was bundled without its message handler.',
+    );
+  }
+}
+
+console.log(
+  `playground worker OK (${workers.join(', ')})`,
+);

--- a/apps/docs/src/scripts/playground.ts
+++ b/apps/docs/src/scripts/playground.ts
@@ -54,6 +54,22 @@ export const setupPlayground = (): void => {
   let requestId = 0;
   let worker: Worker | null = null;
   let diagramId = 0;
+  let watchdog: ReturnType<typeof setTimeout> | null = null;
+
+  // A worker that never answers is indistinguishable from a slow one, and it
+  // has a real cause: an empty or broken worker chunk still loads as a valid
+  // module, so it fires no `error` event and simply never replies. Without a
+  // deadline the page sits on "Analyzing in worker..." forever, which is how
+  // this shipped unnoticed. Analysis of a large program is legitimately slow,
+  // hence a generous bound rather than a tight one.
+  const ANALYSIS_TIMEOUT_MS = 60_000;
+
+  const clearWatchdog = (): void => {
+    if (watchdog) {
+      clearTimeout(watchdog);
+      watchdog = null;
+    }
+  };
 
   mermaid.initialize({
     startOnLoad: false,
@@ -115,6 +131,7 @@ export const setupPlayground = (): void => {
           return;
         }
 
+        clearWatchdog();
         analyzeButton.disabled = false;
 
         if (event.data.type === 'success') {
@@ -152,6 +169,7 @@ export const setupPlayground = (): void => {
       };
 
       worker.addEventListener('error', (event) => {
+        clearWatchdog();
         analyzeButton.disabled = false;
         status.textContent = 'Worker failed.';
         showText(event.message);
@@ -176,6 +194,21 @@ export const setupPlayground = (): void => {
         : 'Running sample',
     );
     resetOutput();
+    clearWatchdog();
+    const pending = requestId;
+    watchdog = setTimeout(() => {
+      if (pending !== requestId) return;
+      analyzeButton.disabled = false;
+      status.textContent = 'Analysis timed out.';
+      sampleBadge?.replaceChildren();
+      sampleBadge?.append('Timed out');
+      showText(
+        'The analyzer worker did not respond within 60 seconds.\n\n' +
+          'This usually means the worker failed to start rather than that the ' +
+          'program was too large. Reload the page to try again, and check the ' +
+          'browser console for a failed request to the worker script.',
+      );
+    }, ANALYSIS_TIMEOUT_MS);
     getWorker().postMessage({
       type: 'analyze',
       requestId,

--- a/packages/effect-analyzer/src/output/html.ts
+++ b/packages/effect-analyzer/src/output/html.ts
@@ -614,8 +614,8 @@ export function renderInteractiveHTML(
       var pre = document.getElementById('ir-json');
       if (!q) { pre.innerHTML = JSON.stringify(IR_DATA, null, 2); return; }
       var text = JSON.stringify(IR_DATA, null, 2);
-      var escaped = q.replace(/[.*+?^$` + `{}()|\\[\\]\\\\]/g, '\\\\$` + `&');
-      pre.innerHTML = text.replace(new RegExp(escaped, 'gi'), '<mark>$` + `&</mark>');
+      var escaped = q.replace(/[.*+?^\${}()|\\[\\]\\\\]/g, '\\\\$&');
+      pre.innerHTML = text.replace(new RegExp(escaped, 'gi'), '<mark>$&</mark>');
     }
 
     function handleTypeFilter(type) {


### PR DESCRIPTION
The [playground](https://jagreehal.github.io/effect-analyzer/playground/) sits on **"Analyzing in worker..."** forever.

## What was happening

The worker chunk is served as `200 application/javascript` with a body of **zero bytes**:

```
GET /effect-analyzer/_astro/playground-worker-BvRk9kiK.js
200 OK   application/javascript   0 bytes
```

An empty module is a *valid* module. It loads without firing `error`, registers no `message` listener, and never replies. So the client posted its request and waited — indefinitely. Nothing failed loudly in the build or the page.

The existing error handling was not at fault: `playground.ts` already listened for `error`, and the worker already wrapped its work in `.catch`. Neither can fire when there is no script to throw and no listener to catch.

## Root cause

`output/html.ts` spliced a regex across template-literal boundaries to embed a literal `${`:

```js
q.replace(/[.*+?^$` + `{}()|\\[\\]\\\\]/g, '\\\\$` + `&')
```

Bundled through **rolldown** (Vite 8's bundler), that construct silently yields an empty chunk for whichever entry imports `renderInteractiveHTML`. Bisecting the module pinned it exactly:

| Bundled through | Worker chunk |
|---|---|
| line 616 | 75,744 bytes |
| line 617 | **0 bytes** |

Escaping the dollar as `\${` keeps the template open and bundles normally. The second splice was never needed — `$&` is not `${`.

**The rendered HTML is byte-identical before and after** (32,746 bytes both ways), verified against a captured baseline. The viewer is unchanged; only the module's bundling behaviour is.

## This is not docs-only

`renderInteractiveHTML` is exported from the published package. Any consumer bundling it with Vite 8 gets an entry that silently does nothing — hence a `patch` changeset rather than an empty one.

## Two guards, because it failed invisibly in both directions

- **`apps/docs/scripts/check-playground-worker.mjs`**, wired into the docs build. Fails if the worker chunk is missing, empty, or carries no `addEventListener`. Verified by blanking the real chunk — it reports the exact diagnosis. This would have caught the regression before deploy.
- **A 60s watchdog in `playground.ts`.** A worker that never answers now reports a timeout and points at the worker script, instead of spinning forever.

## Verification

Headless browser against the built site:

```
FINAL STATUS: Analysis succeeded. Showing sendMoney from 4 detected programs.
badge: Live viewer
viewer iframe hidden? false
srcdoc bytes: 49298
console errors: none
```

| Check | Result |
|---|---|
| Worker chunk | 0 → 7.1 MB |
| Generated HTML | byte-identical to baseline |
| Docs build (incl. new guard) | exit 0 |
| Analyzer lint | exit 0 |

## Worth reporting upstream

A bundler emitting an empty chunk with no error or warning is arguably a rolldown bug. This construct is legal TypeScript and builds correctly under tsup. Others will hit it the same way.