### PR TITLE
feat: see through type assertions, report accidental hubs, fix the CLI's help and errors

### DIFF
--- a/.changeset/dx-cli-coupling-assertions-watch.md
+++ b/.changeset/dx-cli-coupling-assertions-watch.md
@@ -1,0 +1,15 @@
+---
+'effect-analyzer': minor
+---
+
+Four fixes to what the analyzer could see and what the CLI would tell you.
+
+**Type assertions no longer blind the walker.** `Effect.succeed(1) as Effect.Effect<number>` is the same effect as `Effect.succeed(1)`, but the walker stopped at the `as` and emitted an unknown node — the same for `satisfies`, `!`, `<T>` and parens. On `effect/packages/effect/src`, `Could not determine effect type` drops from 141 nodes to 29, and unknown nodes overall from 262 to 165. `unwrapExpression` already existed in `core-analysis.ts`; it moves to `analysis-utils.ts` so the program walker can reach it without an import cycle, and `state-machine-ast.ts` now re-exports it instead of carrying a fourth copy of the rule that missed `!`.
+
+**`accidental-hub` coupling issue.** A file high on fan-in *and* fan-out is a junction, not an interface: a change to anything it imports can travel to everything that imports it. That combination was previously two ordinary warnings some distance apart in the list. It is now one issue that replaces the pair, sorts below `critical-fanin`, and enters the agent report at `P1`. Bounded below `criticalFanInThreshold`, and suppressed by a known-hub annotation. Adds `accidentalHubs` to `CouplingSummary` and `'accidental-hub'` to `CouplingIssue['type']` — both public, so an exhaustive `switch` needs the new case.
+
+**`--help` matches the parser, and bad flag values are refused.** Seven working flags (`--diff`, `--regression`, `--include-trivial`, `--entry-points`, `--config-leaks`, `--cli-commands`, `--no-test`) and `--format migration` were undocumented; `cli-help.test.ts` now reads the parser's source and fails the build when a flag or format value is missing from the help text. `--format nosuchformat` used to leave the default in place and exit 0 — a CI typo produced the wrong artifact and passed. Unknown *and* missing values for `--format`, `--direction`, `--detail`, `--profile`, `--test-runner` and `--improve-min-priority` are now reported and exit 1. Errors print once, without the Effect `Cause`.
+
+**`--watch` survives an atomic save.** `fs.watch(path)` watches an inode; an editor that saves by writing a temp file and renaming over the original unlinks it, and Node then delivers one `rename` event and nothing further, forever — no error, no exit, a watcher that looks healthy and has stopped watching. It now watches `dirname(path)` and filters on `basename(path)`.
+
+**Breaking:** `parseArgs` returns `{ pathArg, options, errors }` (callers destructuring the first two are unaffected), and a command that passed an unrecognised enum value and ran anyway now exits 1.

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -187,7 +187,7 @@ effect-analyze ./program.ts -w --cache     # With caching for performance
 | `--colocate-suffix <s>` | Custom suffix (default: `effect-analysis`) |
 | `-q, --quiet` | Minimal output |
 | `--no-color` | Disable colors |
-| `-w, --watch` | Watch mode |
+| `-w, --watch` | Watch mode (watches the containing directory, so atomic saves survive) |
 | `--cache` | Cache for watch |
 | `-m, --migration` | Migration assistant |
 | `--diff` | Semantic diff mode |
@@ -282,7 +282,9 @@ import {
 
 1. Create `src/output/my-format.ts` with render function taking `StaticEffectIR`
 2. Export from `src/diagram-entry.ts`
-3. Add the `--format` value in `src/cli-options.ts`, list it in `src/cli-help.ts`, and dispatch it from `main` in `src/cli.ts` (mode bodies live in `src/cli-mode-*.ts`, never inline in `main`)
+3. Add the `--format` value in `src/cli-options.ts`, list it in `src/cli-help.ts`, and dispatch it from `main` in `src/cli.ts` (mode bodies live in `src/cli-mode-*.ts`, never inline in `main`).
+   `cli-help.test.ts` reads the parser's source and fails the build if a flag or `--format` value is missing from `HELP_TEXT`.
+   Enum flags reject unknown and missing values: `parseArgs` is pure and returns `{ pathArg, options, errors }`, leaving the option at its default and pushing a message; `cli.ts` prints the errors and exits 1. Never `process.exit` from the parser
 4. Add to `src/output/auto-diagram.ts` if it should be auto-selected
 
 ### Adding a New Node Type
@@ -338,6 +340,7 @@ pnpm quality     # type-check && test && lint
 - **Visitor pattern:** Recursive walks via `getStaticChildren(node)`
 - **WeakMap caching:** `effectAliasCache`, `nodeTextCache` keyed by SourceFile/Node
 - **Pattern maps:** `ERROR_HANDLER_PATTERNS`, `CONDITIONAL_PATTERNS`, `TRANSFORM_OPS` in `analysis-patterns.ts`
+- **Unwrap before reading an expression:** `unwrapExpression(node)` from `analysis-utils.ts` strips `as`, `satisfies`, `!`, `<T>` and parens. `analysis-utils.ts` imports nothing local, which is what keeps `core-analysis` ↔ `effect-analysis` acyclic
 - **Typed errors:** `AnalysisError` with codes (`NO_EFFECTS_FOUND`, `FILE_NOT_FOUND`)
 - **Semantic roles:** Nodes tagged with `SemanticRole` for filtering/styling
 

--- a/apps/docs/src/content/docs/project/health.mdx
+++ b/apps/docs/src/content/docs/project/health.mdx
@@ -95,6 +95,7 @@ Per-file dependency-graph metrics. Computes fan-in (how many files import this o
 | `high-fanin` | A file with fan-in ≥ 15 — changes to it ripple to many dependents |
 | `critical-fanin` | A file with fan-in ≥ 30 — a true hub; refactoring is expensive |
 | `high-fanout` | A file importing ≥ 20 internal modules — broad scope, hard to test in isolation |
+| `accidental-hub` | A file that is high on both at once — many dependents *and* broad dependency scope; replaces the `high-fanin` + `high-fanout` pair for that file |
 
 Imports are parsed via the TypeScript AST, so `import X`, `import type X`, `export { x } from`, `import('…')` dynamic imports, and side-effect `import './foo'` are all counted; node_modules and `node:` imports are skipped.
 

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -32,6 +32,16 @@ When `path` is a file, the analyzer processes that file. When it is a directory,
 | `--no-metadata` | Exclude analysis metadata from JSON output | off |
 | `-h, --help` | Print help and exit | — |
 
+An unrecognised value for a flag with a fixed set of choices (`--format`, `--direction`, `--detail`, `--profile`, `--test-runner`, `--improve-min-priority`) is an error, not a fallback to the default:
+
+```bash
+$ effect-analyze ./src --format nosuchformat --direction sideways
+Error: Unknown value for --format: nosuchformat. See --help for accepted values.
+Error: Unknown value for --direction: sideways. Accepted: TB, LR, BT, RL.
+```
+
+Every error is reported, then the CLI exits 1 without running. A missing value (the flag last in `argv`) is reported the same way.
+
 ## Diagram Options
 
 | Flag | Description | Default |
@@ -128,6 +138,7 @@ Inspect and search the deterministic rule registry (source lints, effect-lints, 
 | `--test` | Write a `{programName}.test.ts` stub next to each source file |
 | `--test-runner <runner>` | Test runner: `vitest` (default), `jest`, `mocha` |
 | `--test-overwrite` | Overwrite existing test files instead of skipping |
+| `--no-test` | Disable an earlier `--test` (e.g. from a shared alias or script) |
 
 ## Directory Mode Options
 

--- a/apps/docs/src/content/docs/reference/coupling.mdx
+++ b/apps/docs/src/content/docs/reference/coupling.mdx
@@ -33,6 +33,7 @@ The same `--tsconfig` flag is honored by `--coverage-audit`, `--format architect
 | `high-fanin` | fan-in ≥ 15 (default) | Changes to this file ripple to many dependents |
 | `critical-fanin` | fan-in ≥ 30 (default) | True hub; refactor is expensive and may not be desirable |
 | `high-fanout` | fan-out ≥ 20 (default) | File imports many internal modules — broad scope, hard to test in isolation |
+| `accidental-hub` | fan-in ≥ 15 and fan-out ≥ 20, below critical fan-in (defaults) | Unannotated junction with both many dependents and broad dependency scope |
 
 When a file with `critical-fanin` is annotated as a known hub, it is still surfaced under "Known Hubs (at scale)" as low-impact monitoring info. Growth past the annotated baseline is visible in subsequent reports.
 
@@ -126,6 +127,7 @@ Coupling issues fold into `--agent-report` under `category: 'architecture'`. By 
 | Issue type | Priority |
 |---|---|
 | `critical-fanin` (unannotated) | P1 |
+| `accidental-hub` | P1 |
 | `high-fanin` (unannotated) | P2 |
 | `high-fanout` | P3 |
 | `hub-without-annotation` | P3 |

--- a/packages/effect-analyzer/src/agent-report.ts
+++ b/packages/effect-analyzer/src/agent-report.ts
@@ -64,7 +64,12 @@ export interface AgentPerformanceIssue {
 }
 
 export interface AgentCouplingIssue {
-  readonly type: 'high-fanin' | 'critical-fanin' | 'high-fanout' | 'hub-without-annotation';
+  readonly type:
+    | 'high-fanin'
+    | 'critical-fanin'
+    | 'high-fanout'
+    | 'accidental-hub'
+    | 'hub-without-annotation';
   readonly filePath: string;
   readonly projectFilePath: string;
   readonly metric: string;
@@ -289,6 +294,7 @@ export interface CouplingPriorityMap {
   readonly 'critical-fanin'?: AgentImprovement['priority'];
   readonly 'high-fanin'?: AgentImprovement['priority'];
   readonly 'high-fanout'?: AgentImprovement['priority'];
+  readonly 'accidental-hub'?: AgentImprovement['priority'];
   readonly 'hub-without-annotation'?: AgentImprovement['priority'];
 }
 
@@ -296,6 +302,8 @@ const DEFAULT_COUPLING_PRIORITY: Required<CouplingPriorityMap> = {
   'critical-fanin': 'P1',
   'high-fanin': 'P2',
   'high-fanout': 'P3',
+  // Above both of the issues it replaces: the pair is the signal.
+  'accidental-hub': 'P1',
   'hub-without-annotation': 'P3',
 };
 
@@ -396,6 +404,7 @@ export const buildAgentReport = (options: BuildAgentReportOptions): AgentReport 
     'critical-fanin': 'Critical fan-in',
     'high-fanin': 'High fan-in',
     'high-fanout': 'High fan-out',
+    'accidental-hub': 'Accidental hub (high fan-in and fan-out)',
     'hub-without-annotation': 'Hub without annotation',
   };
   for (const cp of couplingIssues) {

--- a/packages/effect-analyzer/src/analysis-utils.ts
+++ b/packages/effect-analyzer/src/analysis-utils.ts
@@ -890,3 +890,31 @@ export function computeSemanticRole(node: StaticFlowNode): SemanticRole {
       return 'unknown';
   }
 }
+
+/**
+ * Unwrap TypeScript expression wrappers: parenthesized, as, non-null,
+ * satisfies, type assertion.
+ *
+ * A type assertion is not a program. `Effect.succeed(1) as Effect.Effect<number>`
+ * is the same effect as `Effect.succeed(1)`, and every analyzer that reads an
+ * expression needs to look through the wrapper before deciding what it is.
+ *
+ * Lives here rather than in `core-analysis.ts`, where it started, because
+ * `effect-analysis.ts` needs the same rule and `core-analysis` already imports
+ * from it. Both import this module, and this module imports neither.
+ */
+export function unwrapExpression(expr: Node): Node {
+  const { SyntaxKind } = loadTsMorph();
+  switch (expr.getKind()) {
+    case SyntaxKind.ParenthesizedExpression:
+    case SyntaxKind.AsExpression:
+    case SyntaxKind.TypeAssertionExpression:
+    case SyntaxKind.NonNullExpression:
+    case SyntaxKind.SatisfiesExpression:
+      return unwrapExpression(
+        (expr as unknown as { getExpression(): Node }).getExpression(),
+      );
+    default:
+      return expr;
+  }
+}

--- a/packages/effect-analyzer/src/cli-help.test.ts
+++ b/packages/effect-analyzer/src/cli-help.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `--help` is the only flag reference a terminal user has, and it is a hand
+ * written literal in a different file from the parser. Nothing tied the two
+ * together, so `cli.ts`'s decomposition could move the parser forward and
+ * leave the help text behind without a single test failing. It did: seven
+ * working flags went undocumented, including `--diff` and `--include-trivial`,
+ * the latter recommended by the analyzer's own output.
+ *
+ * These tests read the parser's source and require every flag and every
+ * accepted enum value to appear in the help text. A flag added to the parser
+ * fails here until it is documented.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { HELP_TEXT } from './cli-help';
+
+const parserSource = readFileSync(join(__dirname, 'cli-options.ts'), 'utf8');
+
+const matchAll = (pattern: RegExp): readonly string[] => [
+  ...new Set([...parserSource.matchAll(pattern)].map((m) => m[1]!)),
+];
+
+/** `arg === '--flag'` and `arg === '-f'`. */
+const comparedFlags = matchAll(/arg === '(-{1,2}[a-z0-9-]+)'/g);
+/** `arg.startsWith('--flag=')`, whose documented spelling omits the `=`. */
+const prefixFlags = matchAll(/startsWith\('(--[a-z0-9-]+)='\)/g);
+
+const ALL_FLAGS = [...new Set([...comparedFlags, ...prefixFlags])].sort();
+
+/**
+ * The `--format` branch is a chain of `value === '...'` comparisons. Reading it
+ * from source keeps this test honest when a format is added.
+ */
+const formatBranch = parserSource.slice(
+  parserSource.indexOf("arg === '--format'"),
+  parserSource.indexOf("} else if (arg === '--export')"),
+);
+const ACCEPTED_FORMATS = [
+  ...new Set([...formatBranch.matchAll(/value === '([a-z0-9-]+)'/g)].map((m) => m[1]!)),
+].sort();
+
+describe('--help', () => {
+  it('finds the parser flags it is meant to describe', () => {
+    // Guards the extraction itself: a regex that silently matches nothing
+    // would make every assertion below vacuously true.
+    expect(ALL_FLAGS.length).toBeGreaterThan(80);
+    expect(ACCEPTED_FORMATS.length).toBeGreaterThan(30);
+  });
+
+  it.each(ALL_FLAGS)('documents %s', (flag) => {
+    expect(HELP_TEXT).toContain(flag);
+  });
+
+  it.each(ACCEPTED_FORMATS)('lists --format %s', (format) => {
+    const formatLine = HELP_TEXT.split('\n').find((l) => l.includes('Output format:'));
+    expect(formatLine).toBeDefined();
+    expect(formatLine).toContain(format);
+  });
+});

--- a/packages/effect-analyzer/src/cli-help.ts
+++ b/packages/effect-analyzer/src/cli-help.ts
@@ -3,10 +3,13 @@
  *
  * Lives apart from the CLI itself: it is a long literal that changes whenever a
  * flag is added, and it has no dependency on anything the CLI does.
+ *
+ * Exported as a value so `cli-help.test.ts` can hold it against the parser's
+ * own flag table. Being a separate literal from the parser is what let the two
+ * drift apart in the first place.
  */
 
-export const printHelp = (): void => {
-  process.stdout.write(`
+export const HELP_TEXT = `
 effect-analyzer - Static analysis for Effect-TS
 
 Usage: effect-analyze [PATH] [options]
@@ -17,7 +20,7 @@ Usage: effect-analyze [PATH] [options]
   verbose output, enhanced Mermaid, colors). Use --no-colocate to skip writing files.
 
 Options:
-  -f, --format <format>    Output format: auto | json | mermaid | mermaid-paths | mermaid-enhanced | mermaid-railway | mermaid-services | mermaid-errors | mermaid-decisions | mermaid-causes | mermaid-concurrency | mermaid-timeline | mermaid-layers | mermaid-retry | mermaid-testability | mermaid-dataflow | mermaid-statechart | svg-statechart | statechart-html | xstate-config | statechart-coverage | stats | showcase | explain | summary | matrix | architecture | api-docs | openapi-paths | openapi-runtime | json-schema (default: auto)
+  -f, --format <format>    Output format: auto | json | mermaid | mermaid-paths | mermaid-enhanced | mermaid-railway | mermaid-services | mermaid-errors | mermaid-decisions | mermaid-causes | mermaid-concurrency | mermaid-timeline | mermaid-layers | mermaid-retry | mermaid-testability | mermaid-dataflow | mermaid-statechart | svg-statechart | statechart-html | xstate-config | statechart-coverage | stats | migration | showcase | explain | summary | matrix | architecture | api-docs | openapi-paths | openapi-runtime | json-schema (default: auto)
   --export <name>          For openapi-runtime: export name of HttpApi (default: first/default)
                            For json-schema: export name of the Schema to convert (required)
   -o, --output <file>      Output file (default: stdout)
@@ -36,6 +39,14 @@ Options:
   --no-color               Disable colored output
   -w, --watch              Watch mode: re-analyze on file change
   -m, --migration          Run migration assistant (report try/catch, Promise.*, etc.)
+  --include-trivial        Keep trivial programs that are filtered from diagrams by default
+  --diff                   Compare two sources and report the structural change between them.
+                           Each source is <git-ref>:<path> or a plain path:
+                           effect-analyze --diff HEAD:./src/a.ts main:./src/a.ts
+  --regression             With --diff: mark structural changes as regressions in the report
+  --entry-points           (Single file) Report the program entry points the analyzer found
+  --config-leaks           (Single file) Report configuration read outside a Config boundary
+  --cli-commands           (Single file) Report the CLI command surface the file defines
   --coverage-audit         Run coverage audit on a directory (discovered/analyzed/failed, %%)
   --show-suspicious-zeros  With --coverage-audit: list files that import Effect but have 0 programs
   --show-top-unknown       With --coverage-audit: list top files by unknown node rate (default: on)
@@ -65,6 +76,7 @@ Options:
   --test                   Write a {programName}.test.ts stub next to each source file (skips existing files unless --test-overwrite)
   --test-runner <runner>   Test runner for --test: vitest (default) | jest | mocha
   --test-overwrite         With --test: overwrite existing test files instead of skipping
+  --no-test                Disable an earlier --test (e.g. from a shared alias or script)
   --cache                  Use cache for watch (future: persist IR)
   --list-rules             Print deterministic rule registry docs (source/effect-lint/strict)
   --index-rules            Print deterministic searchable rule index entries
@@ -92,7 +104,7 @@ Options:
   --performance            Detect performance anti-patterns (sequential could be parallel, unbounded concurrency, etc.) — supports --format json
   --coupling               Analyze module coupling (fan-in/fan-out; annotate intentional hubs with // effect-analyzer-known-hub or @known-hub JSDoc tag; supports --format json)
   --coupling-transitive    With --coupling: compute fan-in transitively through re-exports (consumer of barrel also counted as consumer of barrel's internal modules)
-  --coupling-priority <map>  Override agent-report priority for coupling issue types (comma-separated). Example: --coupling-priority critical-fanin=P0,high-fanout=P2. Valid types: critical-fanin, high-fanin, high-fanout, hub-without-annotation. Valid priorities: P0-P3.
+  --coupling-priority <map>  Override agent-report priority for coupling issue types (comma-separated). Example: --coupling-priority critical-fanin=P0,high-fanout=P2. Valid types: critical-fanin, high-fanin, high-fanout, accidental-hub, hub-without-annotation. Valid priorities: P0-P3.
   --improve                Apply automated fixes for fixable lint issues (use --improve-dry-run to preview)
   --improve-dry-run        Preview fixes without applying (default for --improve)
   --improve-max-fixes <n>  Limit number of fixes to apply
@@ -127,5 +139,9 @@ Examples:
   effect-analyze ./src --format openapi-paths -o paths.json  # Emit OpenAPI paths JSON
   effect-analyze ./src/types.ts --format json-schema --export User  # Exact JSON Schema, from Effect itself
   effect-analyze ./src/api.ts --format openapi-runtime --export TodoApi -o openapi.json  # Runtime OpenApi.fromApi
-` + '\n');
+  effect-analyze --diff HEAD:./src/checkout.ts main:./src/checkout.ts  # Structural diff between two git refs
+`;
+
+export const printHelp = (): void => {
+  process.stdout.write(HELP_TEXT + '\n');
 };

--- a/packages/effect-analyzer/src/cli-invalid-values.test.ts
+++ b/packages/effect-analyzer/src/cli-invalid-values.test.ts
@@ -1,0 +1,75 @@
+/**
+ * An unrecognised enum value used to leave the option at its default and say
+ * nothing. `--format nosuchformat` exited 0 and wrote the `auto` format, so a
+ * typo in a CI pipeline produced the wrong artifact and passed.
+ *
+ * `parseArgs` stays pure and still leaves the option at its default, which is
+ * what `REJECTS` in cli-options.test.ts pins. What is new is that it records
+ * why, so the CLI can report the typo and exit non-zero instead of guessing.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from './cli-options';
+
+const errorsFor = (...args: readonly string[]) => parseArgs(args).errors;
+
+describe('parseArgs invalid values', () => {
+  it('reports nothing for a valid argv', () => {
+    expect(errorsFor('src/a.ts', '--format', 'json', '--direction', 'LR')).toEqual([]);
+  });
+
+  it.each([
+    ['--format', 'nosuchformat'],
+    ['--direction', 'sideways'],
+    ['--detail', 'loud'],
+    ['--profile', 'lax'],
+    ['--test-runner', 'ava'],
+    ['--improve-min-priority', 'P9'],
+  ])('reports %s %s', (flag, value) => {
+    const errors = errorsFor(flag, value);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(flag);
+    expect(errors[0]).toContain(value);
+  });
+
+  it.each([
+    '--format',
+    '--direction',
+    '--detail',
+    '--profile',
+    '--test-runner',
+    '--improve-min-priority',
+  ])('reports a missing value for %s', (flag) => {
+    const errors = errorsFor(flag);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`Missing value for ${flag}`);
+  });
+
+  it('reports the `--flag=value` spelling too', () => {
+    const errors = errorsFor('--profile=lax');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('lax');
+  });
+
+  it('lists the accepted values so the message is actionable', () => {
+    expect(errorsFor('--direction', 'sideways')[0]).toContain('TB');
+  });
+
+  it('points at --help instead of printing a wall for a long list', () => {
+    // `--format` accepts 32 values. Spelling them out puts a paragraph on one
+    // line and buries the typo it is supposed to highlight.
+    const message = errorsFor('--format', 'nosuchformat')[0]!;
+    expect(message).toContain('--help');
+    expect(message).not.toContain('mermaid-testability');
+    expect(message.length).toBeLessThan(120);
+  });
+
+  it('collects every bad value rather than stopping at the first', () => {
+    expect(errorsFor('--format', 'nope', '--detail', 'loud')).toHaveLength(2);
+  });
+
+  it('still leaves the option at its default', () => {
+    expect(parseArgs(['--format', 'nope']).options.format).toBe(
+      parseArgs([]).options.format,
+    );
+  });
+});

--- a/packages/effect-analyzer/src/cli-mode-api.ts
+++ b/packages/effect-analyzer/src/cli-mode-api.ts
@@ -78,8 +78,9 @@ export const runJsonSchemaMode = (resolvedPath: string, options: CLIOptions) =>
   Effect.gen(function* () {
     const exportName = options.openapiExport;
     if (exportName === undefined) {
-      yield* Console.error('json-schema requires --export <name> naming the Schema to convert.');
-      return yield* cliFail('json-schema needs --export');
+      return yield* cliFail(
+        'json-schema requires --export <name> naming the Schema to convert.',
+      );
     }
     if (!options.quiet) yield* Console.error(SECURITY_NOTE);
 

--- a/packages/effect-analyzer/src/cli-options.test.ts
+++ b/packages/effect-analyzer/src/cli-options.test.ts
@@ -281,11 +281,13 @@ describe('parseArgs', () => {
       expect(parseArgs(['src', '--tsgo', 'custom.json'])).toEqual({
         pathArg: 'src',
         options: expect.objectContaining({ tsgoProject: 'custom.json' }),
+        errors: [],
       });
       // No path yet, so `other.ts` stays the path argument rather than the project.
       expect(parseArgs(['--tsgo', 'other.ts'])).toEqual({
         pathArg: 'other.ts',
         options: expect.objectContaining({ tsgoProject: 'tsconfig.json' }),
+        errors: [],
       });
     });
   });
@@ -350,19 +352,21 @@ describe('parseArgs', () => {
       expect(opts('--test-runner=  jest  ').testRunner).toBe('jest');
     });
 
+    // Was `process.exit(1)` from inside the parser. It now reports through the
+    // same channel as every other bad enum value, so the caller decides.
     it.each([
       ['--test-runner', 'gradle'],
       ['--test-runner=gradle'],
-    ])('exits naming the unknown runner (%s)', (...argv) => {
+    ])('reports the unknown runner without exiting (%s)', (...argv) => {
       const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
         throw new Error('exit');
       }) as never);
-      const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-      expect(() => opts(...argv)).toThrow('exit');
-      expect(exit).toHaveBeenCalledWith(1);
-      expect(write.mock.calls.at(0)?.at(0)).toBe(
-        'Unknown test runner: gradle. Use vitest, jest, or mocha.\n',
-      );
+      const { errors, options } = parseArgs(argv);
+      expect(exit).not.toHaveBeenCalled();
+      expect(errors).toEqual([
+        'Unknown value for --test-runner: gradle. Accepted: vitest, jest, mocha.',
+      ]);
+      expect(options.testRunner).toBe('vitest');
     });
   });
 
@@ -432,6 +436,7 @@ describe('parseArgs', () => {
           improveDryRun: true,
           diffSources: [],
         }),
+        errors: [],
       });
     });
 

--- a/packages/effect-analyzer/src/cli-options.ts
+++ b/packages/effect-analyzer/src/cli-options.ts
@@ -101,6 +101,7 @@ const VALID_COUPLING_TYPES: ReadonlySet<CouplingIssueType> = new Set([
   'critical-fanin',
   'high-fanin',
   'high-fanout',
+  'accidental-hub',
   'hub-without-annotation',
 ]);
 const VALID_PRIORITIES = new Set(['P0', 'P1', 'P2', 'P3'] as const);
@@ -119,9 +120,38 @@ function parseCouplingPriority(raw: string): CouplingPriorityMap | null {
   return Object.keys(map).length > 0 ? (map) : null;
 }
 
-export function parseArgs(args: readonly string[]): { pathArg: string | undefined; options: CLIOptions } {
+/** Spelled out for the error messages; the parser still matches on literals. */
+const DIRECTION_VALUES = ['TB', 'LR', 'BT', 'RL'] as const;
+const DETAIL_VALUES = ['compact', 'standard', 'verbose'] as const;
+const PROFILE_VALUES = ['strict', 'ci', 'migration', 'docs'] as const;
+const TEST_RUNNER_VALUES = ['vitest', 'jest', 'mocha'] as const;
+
+export function parseArgs(args: readonly string[]): {
+  pathArg: string | undefined;
+  options: CLIOptions;
+  errors: readonly string[];
+} {
+  // Records the typo and leaves the option at its default, so the caller can
+  // refuse to run instead of analyzing with something the user did not ask for.
+  // Omit `accepted` when the list is too long to print (`--format` has 32).
+  const errors: string[] = [];
+  const rejectValue = (
+    flag: string,
+    value: string | undefined,
+    accepted?: readonly string[],
+  ): void => {
+    const hint = accepted
+      ? `Accepted: ${accepted.join(', ')}.`
+      : 'See --help for accepted values.';
+    errors.push(
+      value === undefined
+        ? `Missing value for ${flag}. ${hint}`
+        : `Unknown value for ${flag}: ${value}. ${hint}`,
+    );
+  };
+
   let pathArg: string | undefined;
-      let format: CLIOptions['format'] = 'auto';
+  let format: CLIOptions['format'] = 'auto';
   let output: string | undefined;
   let pretty = true;
   let includeMetadata = true;
@@ -258,6 +288,8 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
         value === 'openapi-runtime'
       ) {
         format = value;
+      } else {
+        rejectValue('--format', value);
       }
     } else if (arg === '--export') {
       openapiExport = args[++i];
@@ -278,11 +310,15 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
         value === 'RL'
       ) {
         direction = value;
+      } else {
+        rejectValue('--direction', value, DIRECTION_VALUES);
       }
     } else if (arg === '--detail') {
       const value = args[++i];
       if (value === 'compact' || value === 'standard' || value === 'verbose') {
         detail = value;
+      } else {
+        rejectValue('--detail', value, DETAIL_VALUES);
       }
     } else if (arg === '--tsconfig') {
       tsconfig = args[++i];
@@ -407,11 +443,15 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
       const value = args[++i];
       if (value === 'strict' || value === 'ci' || value === 'migration' || value === 'docs') {
         profile = value;
+      } else {
+        rejectValue('--profile', value, PROFILE_VALUES);
       }
     } else if (arg.startsWith('--profile=')) {
       const value = arg.slice('--profile='.length);
       if (value === 'strict' || value === 'ci' || value === 'migration' || value === 'docs') {
         profile = value;
+      } else {
+        rejectValue('--profile', value, PROFILE_VALUES);
       }
     } else if (arg === '--export-session') {
       exportSession = args[++i];
@@ -483,7 +523,7 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
       }
       const parsed = parseCouplingPriority(raw);
       if (!parsed) {
-        console.error(`--coupling-priority: invalid value "${raw}". Expected pairs like "critical-fanin=P0,high-fanin=P1". Valid types: critical-fanin, high-fanin, high-fanout, hub-without-annotation. Valid priorities: P0, P1, P2, P3.`);
+        console.error(`--coupling-priority: invalid value "${raw}". Expected pairs like "critical-fanin=P0,high-fanin=P1". Valid types: critical-fanin, high-fanin, high-fanout, accidental-hub, hub-without-annotation. Valid priorities: P0, P1, P2, P3.`);
         process.exit(2);
       }
       couplingPriority = parsed;
@@ -506,6 +546,8 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
       const value = args[++i];
       if (value === 'P0' || value === 'P1' || value === 'P2' || value === 'P3') {
         improveMinPriority = value;
+      } else {
+        rejectValue('--improve-min-priority', value, [...VALID_PRIORITIES]);
       }
     } else if (arg === '--test') {
       test = true;
@@ -517,17 +559,18 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
       const value = args[++i];
       if (value === 'vitest' || value === 'jest' || value === 'mocha') {
         testRunner = value;
-      } else if (value !== undefined) {
-        process.stderr.write(`Unknown test runner: ${value}. Use vitest, jest, or mocha.\n`);
-        process.exit(1);
+      } else {
+        // Was `process.stderr.write` + `process.exit(1)` from inside the
+        // parser, which made this branch untestable and killed the process
+        // before the caller could decide anything.
+        rejectValue('--test-runner', value, TEST_RUNNER_VALUES);
       }
     } else if (arg.startsWith('--test-runner=')) {
       const value = arg.slice('--test-runner='.length).trim();
       if (value === 'vitest' || value === 'jest' || value === 'mocha') {
         testRunner = value;
       } else {
-        process.stderr.write(`Unknown test runner: ${value}. Use vitest, jest, or mocha.\n`);
-        process.exit(1);
+        rejectValue('--test-runner', value, TEST_RUNNER_VALUES);
       }
     }
   }
@@ -631,5 +674,5 @@ export function parseArgs(args: readonly string[]): { pathArg: string | undefine
     improveExcludeRules: improveExcludeRules.length > 0 ? improveExcludeRules : undefined,
     improveMinPriority,
   };
-  return { pathArg, options };
+  return { pathArg, options, errors };
 }

--- a/packages/effect-analyzer/src/cli.fatal-output.test.ts
+++ b/packages/effect-analyzer/src/cli.fatal-output.test.ts
@@ -1,0 +1,40 @@
+/**
+ * A mistyped path used to produce three lines: the mode's own actionable
+ * message, a shorter restatement, and `JSON.stringify(cause)` of the Effect
+ * failure. The third leaked `{"_id":"Cause","failures":[...]}` to a user who
+ * has no reason to know the program is written in Effect.
+ */
+import { describe, it, expect } from 'vitest';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(__dirname, '..');
+
+const runCli = (args: readonly string[]) =>
+  spawnSync(process.execPath, [join(repoRoot, 'dist/cli.js'), ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+describe('cli fatal errors', () => {
+  it('reports a missing path once, without internal Effect state', () => {
+    const result = runCli(['./no-such-file.ts']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('no-such-file.ts');
+    expect(result.stderr).not.toContain('_id');
+    expect(result.stderr).not.toContain('Cause');
+    expect(result.stderr).not.toContain('_tag');
+    // The path is named once. Repeating it is what made the real message hard
+    // to find among the restatements.
+    expect(result.stderr.match(/Path not found/g)).toHaveLength(1);
+  });
+
+  it('rejects an unknown --format instead of quietly using the default', () => {
+    const result = runCli([join(repoRoot, 'src'), '--format', 'nosuchformat']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('nosuchformat');
+    expect(result.stderr).not.toContain('_id');
+  });
+});

--- a/packages/effect-analyzer/src/cli.test-stubs.test.ts
+++ b/packages/effect-analyzer/src/cli.test-stubs.test.ts
@@ -109,7 +109,9 @@ describe('cli --test stub generation', () => {
 
       const result = runCli(repoRoot, [sourceFile, '--test', '--test-runner=ava']);
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain('Unknown test runner: ava');
+      // Same rejection, now worded like every other bad enum value and raised
+      // by the CLI rather than by `process.exit` inside the parser.
+      expect(result.stderr).toContain('Unknown value for --test-runner: ava');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/effect-analyzer/src/cli.ts
+++ b/packages/effect-analyzer/src/cli.ts
@@ -53,7 +53,11 @@ import { detectServiceCycles } from './service-cycles';
 
 const main = Effect.gen(function* () {
   const args = process.argv.slice(2);
-  const { pathArg, options } = parseArgs(args);
+  const { pathArg, options, errors: argErrors } = parseArgs(args);
+
+  if (argErrors.length > 0) {
+    return yield* cliFail(argErrors.join('\n'));
+  }
 
   if (options.importSession) {
     const imported = yield* cliTry(() => fs.readFile(resolve(options.importSession!), 'utf-8'));
@@ -91,16 +95,14 @@ const main = Effect.gen(function* () {
     Effect.option,
   );
   if (Option.isNone(s)) {
-    yield* Console.error(`Error: Path not found: ${resolvedPath}`);
-    return yield* cliFail('Path not found');
+    return yield* cliFail(`Path not found: ${resolvedPath}`);
   }
 
   const isDir = s.value.isDirectory();
 
   if (options.coverageAudit) {
     if (!isDir) {
-      yield* Console.error('Error: --coverage-audit requires a directory path');
-      return yield* cliFail('Coverage audit requires directory');
+      return yield* cliFail('--coverage-audit requires a directory path');
     }
     yield* runCoverageAuditCli(resolvedPath, options);
     return Exit.succeed(undefined);
@@ -108,8 +110,7 @@ const main = Effect.gen(function* () {
 
   if (options.serviceCycles) {
     if (!isDir) {
-      yield* Console.error('Error: --service-cycles requires a directory path');
-      return yield* cliFail('Service cycles requires directory');
+      return yield* cliFail('--service-cycles requires a directory path');
     }
     const project = yield* analyzeProject(resolvedPath, {
       tsconfig: options.tsconfig,
@@ -177,8 +178,9 @@ const main = Effect.gen(function* () {
 
   if (options.format === 'openapi-runtime') {
     if (isDir) {
-      yield* Console.error('openapi-runtime requires a file path (entrypoint), not a directory.');
-      return yield* cliFail('openapi-runtime needs entrypoint file');
+      return yield* cliFail(
+        'openapi-runtime requires a file path (entrypoint), not a directory.',
+      );
     }
     yield* runOpenApiRuntime(resolvedPath, options);
     return Exit.succeed(undefined);
@@ -186,8 +188,7 @@ const main = Effect.gen(function* () {
 
   if (options.format === 'json-schema') {
     if (isDir) {
-      yield* Console.error('json-schema requires a file path, not a directory.');
-      return yield* cliFail('json-schema needs a file');
+      return yield* cliFail('json-schema requires a file path, not a directory.');
     }
     yield* runJsonSchemaMode(resolvedPath, options);
     return Exit.succeed(undefined);
@@ -238,7 +239,10 @@ const main = Effect.gen(function* () {
 }).pipe(
   Effect.catch((error: Error) =>
     Effect.gen(function* () {
-      yield* Console.error(`Fatal error: ${error.message}`);
+      // The only place a failed run is reported. Modes carry their detail in
+      // the error itself, so nothing prints ahead of this and nothing needs to
+      // render the Cause behind it.
+      yield* Console.error(`Error: ${error.message}`);
       return Exit.fail(error);
     }),
   ),
@@ -248,11 +252,9 @@ const main = Effect.gen(function* () {
 Effect.runPromise(main).then(
   (exit) => {
     if (Exit.isFailure(exit)) {
-      const cause = exit.cause;
-      const rendered = JSON.stringify(cause);
-      if (rendered) {
-        console.error(`Error: ${rendered}`);
-      }
+      // Already reported by the handler above. Stringifying the Cause here put
+      // `{"_id":"Cause","failures":[...]}` in front of users who have no reason
+      // to know the CLI is written in Effect.
       process.exit(1);
       return;
     }

--- a/packages/effect-analyzer/src/cli.watch.test.ts
+++ b/packages/effect-analyzer/src/cli.watch.test.ts
@@ -55,6 +55,52 @@ describe('effect-analyze --watch', () => {
     expect(currentFrame).toContain('Showing the last valid analysis');
   }, 20_000);
 
+  // `fs.watch` on a file watches that inode. When an editor saves by writing a
+  // temp file and renaming it over the original — Vim with `backupcopy=no`,
+  // and most "atomic save" implementations — the original inode is unlinked
+  // and the watch dies with it. Node delivers one `rename` and then nothing,
+  // for the rest of the process: no error, no exit, a watcher that is still
+  // "running" and permanently deaf.
+  //
+  // The previous test only proves the unlink is noticed. This one proves the
+  // watcher is still alive afterwards, which is the half that was broken.
+  it('keeps watching after the file is replaced rather than modified', async () => {
+    root = mkdtempSync(join(tmpdir(), 'effect-analyzer-atomic-save-'));
+    const source = join(root, 'checkout.ts');
+    writeFileSync(source, VALID_SOURCE, 'utf8');
+
+    child = spawn(
+      process.execPath,
+      [resolve(__dirname, '..', 'dist', 'cli.js'), source, '--watch', '--format', 'mermaid', '--quiet'],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.resume();
+
+    await waitFor(() => stdout, 'flowchart');
+
+    // Replace the file the way an editor does: unlink, then write anew.
+    rmSync(source);
+    writeFileSync(
+      source,
+      VALID_SOURCE.replace('checkout', 'refundOrder').replace("'paid'", "'refunded'"),
+      'utf8',
+    );
+    // The unlink's own event is enough to carry this one, so it proves nothing
+    // about the watcher's health. Wait for it to be spent.
+    await waitFor(() => stdout, 'refundOrder');
+
+    // This is the assertion that matters: an ordinary save, after the replace,
+    // on a watcher whose original inode is gone.
+    writeFileSync(
+      source,
+      VALID_SOURCE.replace('checkout', 'settleInvoice').replace("'paid'", "'settled'"),
+      'utf8',
+    );
+    await waitFor(() => stdout, 'settleInvoice');
+  }, 20_000);
+
   // Watch mode renders through `captureStdout`, which swaps the global
   // `process.stdout.write`. Overlapping analyses restore it in the order they
   // finish, so a burst of saves used to be able to leave stdout pointing at a

--- a/packages/effect-analyzer/src/core-analysis.ts
+++ b/packages/effect-analyzer/src/core-analysis.ts
@@ -18,7 +18,6 @@ import type {
   GetAccessorDeclaration,
   StringLiteral,
   NumericLiteral,
-  ParenthesizedExpression,
   ObjectLiteralExpression,
   PropertyAssignment,
   PropertyAccessExpression,
@@ -71,6 +70,7 @@ import {
   extractServiceRequirements,
 } from './type-extractor';
 import type { EffectProgram } from './analysis-utils';
+import { unwrapExpression } from './analysis-utils';
 import {
   createEmptyStats,
   generateId,
@@ -570,26 +570,6 @@ function simplifyBooleanExpression(expr: string): string {
   // true || X → true
   result = result.replace(/\btrue\b\s*\|\|\s*[^|&]+/g, 'true');
   return result.trim();
-}
-
-/**
- * Unwrap TypeScript expression wrappers: parenthesized, as, non-null, satisfies, type assertion.
- */
-function unwrapExpression(expr: Node): Node {
-  const { SyntaxKind } = loadTsMorph();
-  const kind = expr.getKind();
-  switch (kind) {
-    case SyntaxKind.ParenthesizedExpression:
-    case SyntaxKind.AsExpression:
-    case SyntaxKind.TypeAssertionExpression:
-    case SyntaxKind.NonNullExpression:
-    case SyntaxKind.SatisfiesExpression: {
-      const inner = (expr as ParenthesizedExpression).getExpression();
-      return unwrapExpression(inner);
-    }
-    default:
-      return expr;
-  }
 }
 
 /**

--- a/packages/effect-analyzer/src/coupling-accidental-hub.test.ts
+++ b/packages/effect-analyzer/src/coupling-accidental-hub.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Item 8 from ___temp/coupling-analyzer-improvement-notes.md.
+ *
+ * High fan-in and high fan-out were reported as two independent issues, so the
+ * file that scores on both — the strongest rewrite candidate a coupling report
+ * can surface — read as two ordinary warnings among many. A module that many
+ * files depend on AND that reaches broadly into the codebase is not a stable
+ * interface; it is a junction, and a change to anything it imports can reach
+ * everything that imports it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import './register-node-ts-morph';
+import { analyzeCoupling } from './coupling-analysis';
+
+/**
+ * `hub.ts` imports `leaf0..N` (fan-out) and is imported by `consumer0..N`
+ * (fan-in), so it crosses both thresholds at once. `broad.ts` only imports,
+ * and `popular.ts` is only imported, so each crosses exactly one.
+ */
+const WIDTH = 6;
+
+const buildProject = (root: string): string[] => {
+  const files: string[] = [];
+  const write = (rel: string, content: string) => {
+    const abs = join(root, rel);
+    mkdirSync(abs.slice(0, abs.lastIndexOf('/')), { recursive: true });
+    writeFileSync(abs, content);
+    files.push(abs);
+  };
+
+  for (let i = 0; i < WIDTH; i++) {
+    write(`src/leaf${i}.ts`, `export const leaf${i} = ${i};\n`);
+  }
+
+  const importLeaves = (name: string) =>
+    Array.from(
+      { length: WIDTH },
+      (_, i) => `import { leaf${i} } from './leaf${i}';`,
+    ).join('\n') +
+    `\nexport const ${name} = [${Array.from({ length: WIDTH }, (_, i) => `leaf${i}`).join(', ')}];\n`;
+
+  write('src/hub.ts', importLeaves('hub'));
+  write('src/broad.ts', importLeaves('broad'));
+  write('src/popular.ts', 'export const popular = 1;\n');
+
+  for (let i = 0; i < WIDTH; i++) {
+    write(
+      `src/consumer${i}.ts`,
+      `import { hub } from './hub';\n` +
+        `import { popular } from './popular';\n` +
+        `export const consumer${i} = [hub, popular];\n`,
+    );
+  }
+
+  return files;
+};
+
+describe('accidental hubs', () => {
+  let root: string;
+  let filePaths: string[];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'effect-analyze-accidental-hub-'));
+    filePaths = buildProject(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const analyze = () =>
+    analyzeCoupling(filePaths, root, {
+      highFanInThreshold: 5,
+      criticalFanInThreshold: 50,
+      highFanOutThreshold: 5,
+    });
+
+  const issuesFor = (name: string) =>
+    analyze().issues.filter((i) => i.projectFilePath.endsWith(name));
+
+  it('reports the file that is high on both axes as one accidental hub', () => {
+    const types = issuesFor('hub.ts').map((i) => i.type);
+    expect(types).toContain('accidental-hub');
+    // Replaces the two independent warnings rather than adding a third.
+    expect(types).not.toContain('high-fanin');
+    expect(types).not.toContain('high-fanout');
+  });
+
+  it('names both numbers, since either alone understates the problem', () => {
+    const issue = issuesFor('hub.ts').find((i) => i.type === 'accidental-hub')!;
+    expect(issue.description).toContain('6');
+    expect(issue.estimatedImpact).toBe('high');
+  });
+
+  it('leaves a file that is high on only one axis alone', () => {
+    expect(issuesFor('broad.ts').map((i) => i.type)).toEqual(['high-fanout']);
+    expect(issuesFor('popular.ts').map((i) => i.type)).toEqual(['high-fanin']);
+  });
+
+  it('counts accidental hubs in the summary', () => {
+    expect(analyze().summary.accidentalHubs).toBe(1);
+  });
+
+  it('respects a known-hub annotation, which is what it is for', () => {
+    const hubPath = filePaths.find((p) => p.endsWith('hub.ts'))!;
+    writeFileSync(
+      hubPath,
+      `// effect-analyzer-known-hub public barrel\n` +
+        Array.from(
+          { length: 6 },
+          (_, i) => `import { leaf${i} } from './leaf${i}';`,
+        ).join('\n') +
+        `\nexport const hub = [${Array.from({ length: 6 }, (_, i) => `leaf${i}`).join(', ')}];\n`,
+    );
+
+    expect(issuesFor('hub.ts').map((i) => i.type)).not.toContain(
+      'accidental-hub',
+    );
+    expect(analyze().summary.accidentalHubs).toBe(0);
+  });
+});

--- a/packages/effect-analyzer/src/coupling-analysis.ts
+++ b/packages/effect-analyzer/src/coupling-analysis.ts
@@ -35,7 +35,12 @@ export interface FileCouplingMetrics {
 }
 
 export interface CouplingIssue {
-  readonly type: 'high-fanin' | 'critical-fanin' | 'high-fanout' | 'hub-without-annotation';
+  readonly type:
+    | 'high-fanin'
+    | 'critical-fanin'
+    | 'high-fanout'
+    | 'accidental-hub'
+    | 'hub-without-annotation';
   readonly filePath: string;
   readonly projectFilePath: string;
   readonly metric: string;
@@ -61,6 +66,8 @@ export interface CouplingSummary {
   readonly highFanInFiles: number;
   readonly criticalFanInFiles: number;
   readonly highFanOutFiles: number;
+  /** High on fan-in and fan-out at once; see the detection site for why. */
+  readonly accidentalHubs: number;
   readonly knownHubs: number;
   readonly unannotatedHubs: number;
   readonly parseFailures: number;
@@ -430,9 +437,44 @@ export function analyzeCoupling(
   let highFanInFiles = 0;
   let criticalFanInFiles = 0;
   let highFanOutFiles = 0;
+  let accidentalHubFiles = 0;
   let unannotatedHubs = 0;
 
   for (const m of metrics) {
+    /**
+     * High on both axes at once. Reported as one issue rather than a
+     * `high-fanin` and a `high-fanout` sitting apart in the list, because the
+     * combination is what makes it a rewrite candidate: dependents above it,
+     * a broad reach below it, and every change travelling between the two.
+     *
+     * Bounded below `criticalFanIn`, which is already the loudest single
+     * signal a file can raise and does not need folding into another.
+     */
+    if (
+      !m.knownHub &&
+      m.fanIn >= highFanIn &&
+      m.fanIn < criticalFanIn &&
+      m.fanOut >= highFanOut
+    ) {
+      issues.push({
+        type: 'accidental-hub',
+        filePath: m.filePath,
+        projectFilePath: m.projectFilePath,
+        metric: 'fan-in',
+        value: m.fanIn,
+        threshold: highFanIn,
+        description: `File "${m.projectFilePath}" has fan-in ${m.fanIn} and fan-out ${m.fanOut} — ${m.fanIn} files depend on it while it reaches into ${m.fanOut} others`,
+        suggestion:
+          'Split the parts dependents actually use from the parts that pull in the rest of the codebase. Add a `// effect-analyzer-known-hub <reason>` comment or `@known-hub <reason>` JSDoc tag if this junction is intentional.',
+        estimatedImpact: 'high',
+        knownHub: false,
+        knownHubReason: '',
+      });
+      accidentalHubFiles++;
+      unannotatedHubs++;
+      continue;
+    }
+
     if (m.fanIn >= criticalFanIn) {
       if (m.knownHub) {
         issues.push({
@@ -506,9 +548,10 @@ export function analyzeCoupling(
 
   const typeOrder: Record<CouplingIssue['type'], number> = {
     'critical-fanin': 0,
-    'high-fanin': 1,
-    'hub-without-annotation': 2,
-    'high-fanout': 3,
+    'accidental-hub': 1,
+    'high-fanin': 2,
+    'hub-without-annotation': 3,
+    'high-fanout': 4,
   };
   const sortedIssues = [...issues].sort((a, b) => {
     const cmp = typeOrder[a.type] - typeOrder[b.type];
@@ -531,6 +574,7 @@ export function analyzeCoupling(
       highFanInFiles,
       criticalFanInFiles,
       highFanOutFiles,
+      accidentalHubs: accidentalHubFiles,
       knownHubs: thresholdKnownHubs.length,
       unannotatedHubs,
       parseFailures,
@@ -735,6 +779,7 @@ export const renderCouplingReport = (analysis: CouplingAnalysis): string => {
   lines.push(`- High fan-in files: ${s.highFanInFiles}`);
   lines.push(`- Critical fan-in files: ${s.criticalFanInFiles}`);
   lines.push(`- High fan-out files: ${s.highFanOutFiles}`);
+  lines.push(`- Accidental hubs (high fan-in and fan-out): ${s.accidentalHubs}`);
   lines.push(`- Known hubs (annotated at scale): ${s.knownHubs}`);
   lines.push(`- Unannotated hubs: ${s.unannotatedHubs}`);
   if (s.parseFailures > 0) {

--- a/packages/effect-analyzer/src/effect-analysis-assertions.test.ts
+++ b/packages/effect-analyzer/src/effect-analysis-assertions.test.ts
@@ -1,0 +1,58 @@
+/**
+ * A type assertion is not a program. `Effect.succeed(1) as Effect.Effect<number>`
+ * is the same effect as `Effect.succeed(1)`, and the analyzer used to give up
+ * at the `as` and emit an unknown node.
+ *
+ * Auditing Effect's own source found this is the single largest resolution gap
+ * in the analyzer: of 141 nodes landing in the `Could not determine effect
+ * type` bucket, 108 were `AsExpression`. Effect code asserts constantly, so the
+ * walker was blinding itself on one of the language's most common wrappers.
+ *
+ * `unwrapExpression` in core-analysis.ts already handled exactly this set. It
+ * was never exported, so the classifier could not reach it.
+ */
+import { describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
+import './register-node-ts-morph';
+import { analyzeEffectSource } from './static-analyzer';
+import type { StaticEffectIR } from './types';
+
+const analyze = (src: string): Promise<readonly StaticEffectIR[]> =>
+  Effect.runPromise(analyzeEffectSource(src));
+
+/**
+ * The whole IR as text. These tests ask whether a value appears anywhere in the
+ * tree, which is a substring question, so walking the nodes to ask it was work
+ * the serializer already does.
+ */
+const text = (irs: readonly StaticEffectIR[]): string => JSON.stringify(irs);
+
+describe('type assertions are transparent', () => {
+  it.each([
+    ['as', `yield* (Effect.succeed(1) as Effect.Effect<number>);`],
+    ['satisfies', `yield* (Effect.succeed(1) satisfies Effect.Effect<number>);`],
+    ['non-null', `yield* Effect.succeed(1)!;`],
+    ['parenthesized', `yield* ((Effect.succeed(1)));`],
+  ])('sees through a %s wrapper', async (_label, line) => {
+    const irs = await analyze(`
+import { Effect } from 'effect';
+export const program = Effect.gen(function* () {
+  ${line}
+});
+`);
+
+    expect(irs.length).toBeGreaterThan(0);
+    expect(text(irs)).not.toContain('Could not determine effect type');
+  });
+
+  it('keeps the asserted call recognisable as the effect it is', async () => {
+    const irs = await analyze(`
+import { Effect } from 'effect';
+export const program = Effect.gen(function* () {
+  yield* (Effect.fail('BOOM') as Effect.Effect<never, 'BOOM'>);
+});
+`);
+
+    expect(text(irs)).toContain('"callee":"Effect.fail"');
+  });
+});

--- a/packages/effect-analyzer/src/effect-analysis.ts
+++ b/packages/effect-analyzer/src/effect-analysis.ts
@@ -46,6 +46,7 @@ import {
   extractJSDocTags,
   computeDisplayName,
   computeSemanticRole,
+  unwrapExpression,
 } from './analysis-utils';
 import {
   ERROR_HANDLER_PATTERNS,
@@ -316,6 +317,17 @@ export const analyzeEffectExpression = (
 ): Effect.Effect<StaticFlowNode, AnalysisError> =>
   Effect.gen(function* () {
     const { SyntaxKind } = loadTsMorph();
+
+    /**
+     * A type assertion is not a program. Look through `as`, `satisfies`, `!`,
+     * `<T>` and parentheses before deciding what this expression is, or the
+     * walker stops at the wrapper and reports an unknown node.
+     *
+     * Auditing Effect's own source found this was the analyzer's single
+     * largest resolution gap: 108 of the 141 nodes in the `Could not determine
+     * effect type` bucket were `AsExpression`.
+     */
+    node = unwrapExpression(node);
 
     // Handle function wrappers that return an Effect (common in workflow APIs)
     if (

--- a/packages/effect-analyzer/src/state-machine-ast.ts
+++ b/packages/effect-analyzer/src/state-machine-ast.ts
@@ -20,23 +20,14 @@ import type { SourceLocation } from './types';
 
 export type SourceFile = ReturnType<Project['createSourceFile']>;
 
-/** Strip `as const`, `satisfies`, parentheses and `<T>` assertions. */
-export function unwrap(node: Node): Node {
-  let cur = node;
-  for (;;) {
-    const k = cur.getKind();
-    if (
-      k === SyntaxKind.AsExpression ||
-      k === SyntaxKind.SatisfiesExpression ||
-      k === SyntaxKind.ParenthesizedExpression ||
-      k === SyntaxKind.TypeAssertionExpression
-    ) {
-      cur = (cur as unknown as { getExpression(): Node }).getExpression();
-      continue;
-    }
-    return cur;
-  }
-}
+/**
+ * Strip `as const`, `satisfies`, parentheses, `!` and `<T>` assertions.
+ *
+ * The same rule the program walker uses, so a wrapper cannot be transparent in
+ * one analyzer and opaque in the other. This copy also missed `!`.
+ */
+import { unwrapExpression as unwrap } from './analysis-utils';
+export { unwrap };
 
 /** Read a string-literal value (after unwrapping `as const`), or undefined. */
 export function stringValue(node: Node | undefined): string | undefined {

--- a/packages/effect-analyzer/src/watch-mode.ts
+++ b/packages/effect-analyzer/src/watch-mode.ts
@@ -10,6 +10,7 @@
  */
 
 import { watch } from 'fs';
+import { basename, dirname } from 'path';
 import { Console, Effect } from 'effect';
 import { makeRetainer, type RetainedAnalysis } from './analysis-retention';
 import { captureStdout } from './capture-stdout';
@@ -145,7 +146,16 @@ export const runWatchMode = <O>(
         ).catch(() => undefined),
       );
 
-      const watcher = watch(path, { persistent: true }, () => {
+      /**
+       * The directory, not the file. `fs.watch` on a file watches that inode,
+       * and an editor saving by rename unlinks it: Node then delivers one
+       * `rename` and nothing ever again, leaving a registered, permanently deaf
+       * watcher. A directory inode outlives its children. A null `filename` is
+       * documented as possible, so it refreshes rather than being dropped.
+       */
+      const watched = basename(path);
+      const watcher = watch(dirname(path), { persistent: true }, (_event, filename) => {
+        if (filename !== null && basename(filename) !== watched) return;
         if (debounce) clearTimeout(debounce);
         debounce = setTimeout(refresh, DEBOUNCE_MS);
       });


### PR DESCRIPTION
Four changes to what the analyzer can see and what the CLI will tell you. One commit, one changeset.

## See through type assertions

`Effect.succeed(1) as Effect.Effect<number>` is the same effect as `Effect.succeed(1)`, but the walker stopped at the `as` and emitted an unknown node — likewise for `satisfies`, `!`, `<T>` and parens. Effect code asserts constantly, so this was the analyzer's largest single resolution gap.

On `effect/packages/effect/src` (460 files, 346 with programs):

| | before | after |
|---|---|---|
| `Could not determine effect type` | 141 | 29 |
| unknown nodes, all reasons | 262 | 165 |

`unwrapExpression` moves to `analysis-utils.ts`, which imports nothing local, so both `core-analysis` and `effect-analysis` reach it without a cycle. `state-machine-ast.ts` re-exports it instead of keeping a fourth copy of the rule — the only copy that missed `!`.

## `accidental-hub` coupling issue

A file high on fan-in *and* fan-out is a junction, not an interface: a change to anything it imports can travel to everything that imports it. That combination was previously two ordinary warnings some distance apart in the list.

It is now one issue that replaces the pair, sorts below `critical-fanin`, and enters the agent report at `P1`. Bounded below `criticalFanInThreshold` (critical fan-in is already the loudest signal a single file can raise) and suppressed by a known-hub annotation.

Adds `accidentalHubs` to `CouplingSummary` and `'accidental-hub'` to `CouplingIssue['type']` — both public, so an exhaustive `switch` needs the new case.

## `--help` matches the parser, bad values are refused

Seven working flags (`--diff`, `--regression`, `--include-trivial`, `--entry-points`, `--config-leaks`, `--cli-commands`, `--no-test`) and `--format migration` were undocumented. `cli-help.test.ts` now reads the parser's source and fails the build when a flag or format value is missing from the help text.

`--format nosuchformat` used to leave the option at its default and exit 0 — a CI typo produced the wrong artifact and passed. Unknown *and* missing values for `--format`, `--direction`, `--detail`, `--profile`, `--test-runner` and `--improve-min-priority` are now reported and exit 1:

\`\`\`
Error: Unknown value for --direction: sideways. Accepted: TB, LR, BT, RL.
Error: Unknown value for --format: nosuchformat. See --help for accepted values.
\`\`\`

Errors print once, without the Effect `Cause` — which only ever told users the CLI is written in Effect.

## `--watch` survives an atomic save

`fs.watch(path)` watches an inode. An editor that saves by writing a temp file and renaming it over the original unlinks it, and Node then delivers one `rename` event and nothing further, forever. No error, no exit: a watcher that looks healthy and has stopped watching. It now watches `dirname(path)` and filters on `basename(path)`.

## Breaking

- `parseArgs` returns `{ pathArg, options, errors }`. Callers destructuring the first two are unaffected; a deep-equality assertion on the whole result needs the new key.
- A command that passed an unrecognised enum value and ran anyway now exits 1.

## Docs and skill

`reference/cli.mdx` (invalid-value behaviour, `--no-test`), `reference/coupling.mdx` and `project/health.mdx` (`accidental-hub`), and the `effect-analyzer` skill (help/parser contract, `unwrapExpression`, watch behaviour).

## Verification

\`pnpm quality\` green: 1537 tests, 101 files, type-check and lint clean.