### PR TITLE
feat: make effect-analyze a drop-in replacement for the effect-tsgo CLI

### DIFF
--- a/.changeset/effect-tsgo-cli.md
+++ b/.changeset/effect-tsgo-cli.md
@@ -1,0 +1,35 @@
+---
+'effect-analyzer': minor
+---
+
+`effect-analyze` is now a drop-in replacement for the `effect-tsgo` CLI.
+
+`effect-analyze diagnostics` takes the same flags as `effect-tsgo diagnostics`
+and forwards them untouched, so `@effect/tsgo` validates its own flags, reads
+your project's `@effect/language-service` plugin configuration and picks its own
+exit code. Its output is passed through: `text`, `pretty` and `github-actions`
+are byte-identical, including diagnostic order and the summary trailer.
+`setup`, `config`, `patch`, `unpatch` and `get-exe-path` are forwarded too, so a
+single CLI covers both configuration and diagnostics.
+
+What it adds is the analyzer's own AST rules in the same stream. Every JSON
+entry carries a `source` (`tsgo` or `analyzer`) alongside upstream's schema, so
+a consumer can tell a type-aware Effect diagnostic from one of ours — and both
+from a TypeScript compiler error. Analyzer rules carry `code: 0`, outside the
+`377xxx` Effect range, so filtering on that range behaves exactly as before.
+`--no-analyzer` reports only the language service.
+
+New in `--lint-source`:
+
+- `--fail-on=error|warning|info` gates the exit status on severity. Without it a
+  run stays advisory and never changes the exit code.
+- Findings carry `source` and, for language service diagnostics, the `377xxx`
+  `code` and end position.
+- The summary reports what the language service covered
+  (`summary.tsgo.filesChecked` and `unchecked`), so a partially checked run is
+  distinguishable from a clean one.
+
+Also fixes truncated output: piping a report larger than the pipe buffer cut it
+mid-string, because the CLI exited before stdout had drained.
+
+Requires `@effect/tsgo` 0.39.0.

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -11,6 +11,7 @@ Static analysis tool for Effect-TS programs. Parses TypeScript via `ts-morph`, b
 
 ```
 CLI (cli.ts — dispatch only)
+  → cli-diagnostics.ts (the `diagnostics` subcommand + `@effect/tsgo` proxying)
   → cli-options.ts (parseArgs → CLIOptions), cli-help.ts (--help text)
   → cli-support.ts (CliError, styling, path + output helpers)
   → cli-mode-*.ts (one module per mode: analysis, project, api, statechart,
@@ -168,6 +169,49 @@ effect-analyze ./program.ts --watch        # Re-analyze on file change
 effect-analyze ./program.ts -w --cache     # With caching for performance
 ```
 
+### `@effect/tsgo` relationship
+
+`effect-analyze` is a drop-in replacement for the `effect-tsgo` CLI, and the
+rule that keeps it one is: **never reimplement what `@effect/tsgo` already
+does.**
+
+- `effect-analyze setup | config | patch | unpatch | get-exe-path` spawn the
+  installed `@effect/tsgo` binary verbatim (`cli-diagnostics.ts`,
+  `PROXIED_TSGO_COMMANDS`). Do not reimplement these — the interactive rule
+  picker and the binary patcher move on upstream's release cadence.
+- `effect-analyze diagnostics` forwards argv untouched, so upstream validates
+  its own flags, applies its own `--severity` semantics and picks its own exit
+  code. Only `--fail-on` and `--no-analyzer` are consumed by us
+  (`splitDiagnosticsArgs`). A flag of our own is added there and nowhere else.
+- Upstream's stdout is passed through. `text`, `pretty` and `github-actions`
+  are byte-identical when the analyzer has nothing to add; `--format json` is
+  re-serialised only to attach `source` to every entry, preserving upstream's
+  `diagnostics` array entry for entry and in order.
+- When upstream produces no report — a failed invocation, or `--help` — its
+  stdout, stderr and status pass through untouched and no gating is applied
+  (`producedReport`). Upstream exits 1 for failed invocations exactly as it does
+  for a run that found errors, so status alone cannot tell them apart; `--help`
+  exits 0.
+- `--project` and `--file` together are a union, as upstream treats them.
+
+No `--lspconfig` is ever synthesised. `@effect/tsgo` reads the project's own
+plugin entry, whose canonical name is **`@effect/language-service`** (upstream
+`etscore.EffectPluginName`), not `@effect/tsgo`. Getting that name wrong once
+cost real user configuration: the lookup missed, fell back to `{}`, and passing
+that as `--lspconfig` silently replaced every configured severity with the rule
+defaults. Fixtures that also used the wrong name hid it. If a project has no
+plugin entry the language service is off and `filesChecked` is `0` — that is
+upstream's behaviour, to be reported, not worked around.
+
+Parity is enforced by tests that run both binaries and compare
+(`cli.diagnostics.test.ts`). Changing rendering, ordering or exit codes here
+means changing those tests, which is the signal to ask whether the change
+belongs upstream instead.
+
+Diagnostic identity: `LintFinding.fingerprint` (`fingerprintOf`) is frozen —
+baselines from earlier releases carry it and `--fail-on-new` compares against
+it. Adding a field to that key renumbers every existing finding.
+
 ### All CLI Flags
 
 | Flag | Description |
@@ -180,6 +224,7 @@ effect-analyze ./program.ts -w --cache     # With caching for performance
 | `--pretty` | Pretty-print (default) |
 | `--tsconfig <path>` | Custom tsconfig.json path |
 | `--tsgo[=<tsconfig>]` | Merge official `@effect/tsgo` diagnostics (TypeScript 7+) |
+| `--fail-on <severity>` | Exit 1 on a finding at or above `error`/`warning`/`info` (for `--lint-source`; omit for an advisory run) |
 | `--no-metadata` | Exclude metadata |
 | `--colocate` | Single-file: write colocated .md |
 | `--no-colocate` | Project mode: skip writing files |

--- a/apps/docs/src/content/docs/agent-guardrails.mdx
+++ b/apps/docs/src/content/docs/agent-guardrails.mdx
@@ -20,8 +20,48 @@ sentence the agent can act on. Turn them on. This page covers the layer above: w
 program requires, what it can fail with, how it retries, and which services it reaches.
 
 <Aside type="tip">
-Run both. `--tsgo` merges the official type-aware Effect diagnostics into the same
-report as the analyzer's AST checks: `effect-analyze ./src --lint-source --tsgo=./tsconfig.json`.
+Run both, from one command. `effect-analyze diagnostics` is a drop-in replacement for
+`effect-tsgo diagnostics` that reports the analyzer's AST rules in the same stream:
+
+```bash
+npx effect-analyze diagnostics --project tsconfig.json --format json
+```
+
+Or merge them into a lint-source run: `effect-analyze ./src --lint-source --tsgo=./tsconfig.json`.
+</Aside>
+
+## What an agent can gate on
+
+An agent needs to answer two questions from a check: *is this mine to fix*, and *did
+this run actually pass*. Both are answerable without parsing message text.
+
+Every diagnostic carries a `source` — `tsgo` for a type-aware Effect language service
+diagnostic, `analyzer` for one of ours — and language service entries carry their `code`
+in the `377xxx` range. An entry outside that range is not an Effect advisory, and none of
+these are TypeScript compiler errors, which neither tool emits. Analyzer rules carry
+`code: 0`.
+
+The exit status is a deliberate contract, not a side effect:
+
+```bash
+# Advisory: reports everything, never changes the exit status.
+npx effect-analyze ./src --lint-source --tsgo=./tsconfig.json
+
+# Gated: exit 1 when any finding is at or above the given severity.
+npx effect-analyze ./src --lint-source --tsgo=./tsconfig.json --fail-on=error
+```
+
+For `diagnostics`, the exit code is `effect-tsgo`'s own — `1` on any error, and with
+`--strict` on any warning — and `--fail-on` overrides it, with `--fail-on=none` for a
+purely advisory run.
+
+<Aside type="caution">
+A clean report is only meaningful if something was checked. The language service runs
+only where your tsconfig enables it, via an `@effect/language-service` plugin entry; a
+project without one reports `filesChecked: 0` and exits 0. Have the agent read
+`summary.filesChecked` rather than trust a green exit. `--lint-source --tsgo`
+additionally reports `summary.tsgo.unchecked` — the files it scanned that the tsconfig
+does not include, such as tests excluded from the project.
 </Aside>
 
 ## 1. Hand the agent a prioritized backlog

--- a/apps/docs/src/content/docs/project/source-linter.mdx
+++ b/apps/docs/src/content/docs/project/source-linter.mdx
@@ -54,9 +54,47 @@ service. effect-analyzer does not reimplement them; it merges them in:
 effect-analyze ./src --lint-source --tsgo=./tsconfig.json
 ```
 
+Every merged finding carries a `source` field (`tsgo` or `analyzer`) and, for
+language service diagnostics, the `code` in the `377xxx` range. Gate on those
+rather than on the rule name or the message text.
+
+The run summary also reports what the language service actually covered:
+
+```json
+"summary": {
+  "filesScanned": 12,
+  "tsgo": { "filesChecked": 11, "totalFiles": 11, "unchecked": ["src/scripts/one-off.ts"] }
+}
+```
+
+`unchecked` lists files the linter scanned that the tsconfig does not include,
+so a partially checked run cannot be mistaken for a clean one.
+
 Bare `--tsgo` uses `tsconfig.json`. When options come before the source path,
 use `--tsgo=path/to/tsconfig.json` to provide an explicit project without
 ambiguity.
+
+### Exit codes
+
+A `--lint-source` run is advisory by default: it reports every finding and
+leaves the exit status alone, so a caller can tell an advisory run apart from a
+broken one. `--fail-on` turns findings into a gate:
+
+```bash
+effect-analyze ./src --lint-source --tsgo=./tsconfig.json              # always exit 0
+effect-analyze ./src --lint-source --tsgo=./tsconfig.json --fail-on=error
+effect-analyze ./src --lint-source --tsgo=./tsconfig.json --fail-on=warning
+```
+
+`--fail-on=<severity>` exits 1 when any finding is at or above that severity.
+It is independent of `--fail-on-new`, which gates on the baseline diff instead.
+
+### Or run them as one command
+
+`effect-analyze diagnostics` is a drop-in replacement for
+`effect-tsgo diagnostics` — same flags, same output, same exit codes — that
+reports the analyzer's rules in the same stream. See the
+[CLI reference](/effect-analyzer/reference/cli/#diagnostics).
 
 `@effect/tsgo` is a required effect-analyzer dependency, so the bridge and its
 platform binary are installed automatically. It resolves the target project's

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -62,6 +62,93 @@ Every error is reported, then the CLI exits 1 without running. A missing value (
 | `--coverage-audit` | Run a project-wide coverage audit (see [Coverage Audit](/effect-analyzer/project/coverage-audit/)) |
 | `--migration` | Alias for `--format migration` |
 
+## Commands
+
+`effect-analyze` is a drop-in replacement for the `effect-tsgo` CLI: the same
+subcommands, the same flags, the same exit codes.
+
+| Command | Description |
+|---|---|
+| `diagnostics` | Effect language service diagnostics **plus** the analyzer's own rules, in one stream. Superset of `effect-tsgo diagnostics` |
+| `setup` | Guided `@effect/tsgo` setup (forwarded verbatim) |
+| `config` | Interactive diagnostic severity picker (forwarded verbatim) |
+| `patch` / `unpatch` | Manage the patched TypeScript/Oxlint binaries (forwarded verbatim) |
+| `get-exe-path` | Print the Effect language service executable path (forwarded verbatim) |
+
+### `diagnostics`
+
+| Flag | Description |
+|---|---|
+| `--project <tsconfig>` | Project to check |
+| `--file <path>` | Check a single file |
+| `--progress` | Narrate progress on stderr |
+| `--list-files` | Report detected/supported Effect versions per file |
+| `--format <fmt>` | `json` \| `pretty` \| `text` \| `github-actions` (default: `pretty`) |
+| `--severity <list>` | Filter by comma-separated `error,warning,message` |
+| `--strict` | Also fail the exit code on warnings |
+| `--fail-on <severity>` | Override the gate: `error`, `warning`, `message` or `none` |
+| `--lspconfig <json>` | Inline JSON replacing the project's plugin options |
+| `--no-analyzer` | Language service diagnostics only, omitting the analyzer's rules |
+
+Flags are forwarded to `@effect/tsgo` untouched — it validates them, applies its
+own `--severity` semantics and picks its own exit code — and its output is
+passed through. Only `--fail-on` and `--no-analyzer` are ours. A run with no
+analyzer findings to add is literally the upstream run: `text`, `pretty` and
+`github-actions` output is byte-identical, including the summary trailer and the
+order upstream emitted its diagnostics in.
+
+`--format json` is re-serialised so that every entry carries `source` (`tsgo` or
+`analyzer`), whether or not the analyzer contributed any. Upstream's
+`diagnostics` array is preserved entry for entry and in its original order, with
+analyzer findings appended after it. Analyzer rules carry `code: 0`, outside the
+`377xxx` Effect range, so a consumer that filters on that range sees exactly
+what it saw before.
+
+Your project's configuration is read by `@effect/tsgo` itself, from the
+`@effect/language-service` plugin entry in the tsconfig it is given — the same
+entry your editor uses, so the CLI and the editor agree. Nothing is synthesised
+on your behalf, and configured severities (including turning a rule `off`) are
+honoured exactly.
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": { "floatingEffect": "warning" }
+      }
+    ]
+  }
+}
+```
+
+A project with no such plugin entry has the language service disabled, and
+`filesChecked` will be `0`. That is upstream's behaviour, and it is reported
+rather than worked around: check `summary.filesChecked` if you need to know
+whether a clean report actually examined anything.
+
+```bash
+effect-analyze diagnostics --project tsconfig.json --format json
+effect-analyze diagnostics --project tsconfig.json --format github-actions --strict
+effect-analyze diagnostics --project tsconfig.json --severity error --fail-on=none
+```
+
+Whenever `@effect/tsgo` does not produce a diagnostics report, its output and
+its exit status are passed through untouched, and neither `--fail-on` nor
+analyzer findings are applied to it. That covers failed invocations — a missing
+target, an unsupported flag, unparseable `--lspconfig` — which exit `1` exactly
+as a run that found errors does, so the status alone cannot tell them apart. It
+equally covers `--help`, which prints upstream's help and exits `0`.
+
+`--project` and `--file` given together are a union, as upstream treats them.
+
+Exit codes come from `effect-tsgo diagnostics` itself; analyzer findings can
+only add a failure it would not have seen, under the same rule (`1` when any
+error is present, and with `--strict` also when any warning is). `--fail-on`
+overrides that gate, and `--fail-on=none` makes a run purely advisory.
+
 ## Source Linting
 
 Run deterministic source-level lints. See [Source Linter](/effect-analyzer/project/source-linter/) for the full rule list and workflow.
@@ -73,6 +160,7 @@ Run deterministic source-level lints. See [Source Linter](/effect-analyzer/proje
 | `--sarif` | Emit SARIF 2.1.0 output |
 | `--scorecard` | Emit a per-file lint scorecard |
 | `--baseline <file>` | Compare findings against a baseline session/JSON file |
+| `--fail-on <severity>` | Exit 1 when a finding is at or above `error`, `warning` or `info`. Omit for an advisory run that never changes the exit status |
 | `--fail-on-new` | Exit non-zero when new findings exist vs baseline |
 | `--require-suppression-reason` | Require a reason after `effect-analyzer-disable-next-line` comments |
 | `--fail-on-stale-suppressions` | Exit non-zero when suppression comments are stale |

--- a/packages/effect-analyzer/README.md
+++ b/packages/effect-analyzer/README.md
@@ -20,6 +20,10 @@ Effect v4 is the only supported Effect release. `ts-morph` is bundled automatica
 The official `@effect/tsgo` bridge is also installed as a direct dependency;
 projects that enable it must use native TypeScript 7.
 
+`effect-analyze` is also a drop-in replacement for the `effect-tsgo` CLI, so one
+command covers both toolchain configuration and diagnostics — see
+[below](#a-drop-in-replacement-for-the-effect-tsgo-cli).
+
 ## Quick Start
 
 ```bash
@@ -355,6 +359,34 @@ native audit policy flags return exit code 1 when a threshold fails.
 
 [Learn more →](https://jagreehal.github.io/effect-analyzer/project/coverage-audit/)
 
+### A drop-in replacement for the `effect-tsgo` CLI
+
+`effect-analyze` takes the `effect-tsgo` subcommands and forwards them, so one
+CLI covers configuration and diagnostics:
+
+```bash
+npx effect-analyze diagnostics --project tsconfig.json --format json
+npx effect-analyze setup        # guided @effect/tsgo setup
+npx effect-analyze config       # interactive diagnostic severity picker
+npx effect-analyze patch | unpatch | get-exe-path
+```
+
+`diagnostics` passes its flags to `@effect/tsgo` untouched and passes its
+output back, so `text`, `pretty` and `github-actions` are byte-identical to the
+native binary and its exit codes are unchanged. What it adds is the analyzer's
+own AST rules in the same stream, and a `source` field (`tsgo` or `analyzer`)
+on every JSON entry — alongside the `377xxx` `code` — so a consumer can tell an
+Effect advisory from one of our rules, and both from a compiler error. Analyzer
+rules carry `code: 0`, outside the Effect range. `--no-analyzer` reports only
+the language service; `--fail-on=none` makes a run advisory.
+
+Configuration is read by `@effect/tsgo` itself from the
+`@effect/language-service` plugin entry in your tsconfig — the same entry your
+editor uses — so configured severities are honoured exactly and nothing is
+synthesised on your behalf. A project without that plugin entry has the language
+service disabled and reports `filesChecked: 0`; check that field if you need to
+know whether a clean report examined anything.
+
 ### Source Linting + Official Effect Diagnostics
 
 Run effect-analyzer's deterministic AST checks and merge the official,
@@ -362,7 +394,14 @@ type-aware Effect diagnostics from `@effect/tsgo` in one report:
 
 ```bash
 npx effect-analyze ./src --lint-source --tsgo=./tsconfig.json
+npx effect-analyze ./src --lint-source --tsgo=./tsconfig.json --fail-on=error
 ```
+
+Every finding carries `source` and, for language service diagnostics, the
+`377xxx` `code`. `--fail-on` gates the exit status on severity; without it a run
+is advisory and never changes the exit code. The run summary also reports what
+the language service covered (`summary.tsgo.filesChecked` and `unchecked`), so a
+partially checked run cannot be mistaken for a clean one.
 
 `@effect/tsgo` is a production dependency of effect-analyzer, so no separate
 bridge install is needed. It selects the native compiler artifact for the
@@ -487,7 +526,7 @@ the TypeScript 7 API, or if this package moves back to TypeScript 6.
 
 - Node.js 22+
 - Effect v4
-- TypeScript 7+ when using `--tsgo`
+- TypeScript 7+ when using `--tsgo` or the `diagnostics` command
 
 ## Documentation
 

--- a/packages/effect-analyzer/package.json
+++ b/packages/effect-analyzer/package.json
@@ -101,7 +101,7 @@
     }
   },
   "dependencies": {
-    "@effect/tsgo": "0.37.0",
+    "@effect/tsgo": "0.39.0",
     "ts-morph": "^28.0.0",
     "tsx": "4.23.12"
   },

--- a/packages/effect-analyzer/src/cli-diagnostics.ts
+++ b/packages/effect-analyzer/src/cli-diagnostics.ts
@@ -1,0 +1,542 @@
+/**
+ * `effect-analyze diagnostics` — `effect-tsgo diagnostics` plus the analyzer's
+ * own rules.
+ *
+ * The design rule here is that we do not reimplement anything `@effect/tsgo`
+ * already does. Its argv is forwarded untouched, so it validates its own flags,
+ * applies its own severity semantics and picks its own exit code; its stdout is
+ * passed through byte for byte, so its formatting and its diagnostic ordering
+ * are its own. We strip only our two additions (`--no-analyzer`, `--fail-on`)
+ * and, when we have findings to contribute, splice them into the stream it
+ * produced. A run with nothing to add *is* the upstream run.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { lintSourceCode } from './source-linter';
+import {
+  readTsgoProjectFiles,
+  resolveTsgoBin,
+  spawnTsgoDiagnostics,
+  TsgoDiagnosticsError,
+} from './tsgo-diagnostics';
+
+/**
+ * `@effect/tsgo` subcommands we forward verbatim.
+ *
+ * These configure the toolchain rather than report on it — an interactive rule
+ * picker, the binary patcher — so there is nothing for us to add and every
+ * reason not to reimplement a surface that moves on `@effect/tsgo`'s release
+ * cadence. Forwarding keeps one command for users and no drift for us.
+ */
+export const PROXIED_TSGO_COMMANDS = [
+  'setup',
+  'config',
+  'patch',
+  'unpatch',
+  'get-exe-path',
+] as const;
+
+export type ProxiedTsgoCommand = (typeof PROXIED_TSGO_COMMANDS)[number];
+
+export const isProxiedTsgoCommand = (value: string): value is ProxiedTsgoCommand =>
+  (PROXIED_TSGO_COMMANDS as readonly string[]).includes(value);
+
+/**
+ * Run an `@effect/tsgo` subcommand as-is, inheriting stdio so interactive
+ * prompts work, and return its exit code unchanged.
+ */
+export const proxyTsgoCommand = (command: ProxiedTsgoCommand, args: readonly string[]): number => {
+  const bin = resolveTsgoBin();
+  if (!bin) {
+    throw new TsgoDiagnosticsError(
+      'Unable to resolve @effect/tsgo. Reinstall effect-analyzer and its platform dependencies.',
+    );
+  }
+  const result = spawnSync(process.execPath, [bin, command, ...args], { stdio: 'inherit' });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+};
+
+/** Upstream's severity domain. `message` is what we call `info` elsewhere. */
+export type TsgoSeverity = 'error' | 'warning' | 'message';
+
+export type DiagnosticsFormat = 'json' | 'pretty' | 'text' | 'github-actions';
+
+/**
+ * One diagnostic in `effect-tsgo diagnostics --format json`'s own schema.
+ *
+ * `source` is the single additive field: `tsgo` for a type-aware Effect
+ * language service diagnostic, `analyzer` for one of our AST rules. Analyzer
+ * entries carry `code: 0`, outside the 377xxx Effect range, so a consumer that
+ * filters on that range keeps seeing exactly what it saw before.
+ */
+export interface Diagnostic {
+  readonly file: string;
+  readonly start: number;
+  readonly length: number;
+  readonly line: number;
+  readonly column: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+  readonly severity: TsgoSeverity;
+  readonly code: number;
+  readonly name: string;
+  readonly message: string;
+  readonly source: 'tsgo' | 'analyzer';
+}
+
+/** Code reserved for analyzer rules: never inside the 377xxx Effect range. */
+export const ANALYZER_DIAGNOSTIC_CODE = 0;
+
+const SEVERITY_ORDER: Record<TsgoSeverity, number> = { error: 3, warning: 2, message: 1 };
+
+// =============================================================================
+// Argument handling
+// =============================================================================
+
+export interface DiagnosticsInvocation {
+  /** Arguments to forward to `effect-tsgo diagnostics`, untouched. */
+  readonly forwarded: readonly string[];
+  readonly analyzer: boolean;
+  readonly failOn: TsgoSeverity | 'none' | undefined;
+  readonly project: string | undefined;
+  readonly file: string | undefined;
+  readonly format: DiagnosticsFormat;
+  readonly severity: string | undefined;
+  readonly lspconfig: string | undefined;
+  readonly strict: boolean;
+  readonly progress: boolean;
+  readonly errors: readonly string[];
+}
+
+const FORMATS: readonly string[] = ['json', 'pretty', 'text', 'github-actions'];
+
+const VALUE_FLAGS = ['--project', '--file', '--format', '--severity', '--lspconfig'] as const;
+
+/**
+ * Split our own flags out of argv, noting what we need for our own work.
+ *
+ * Everything else is forwarded verbatim, values included: an unknown flag, an
+ * unsupported `--format` or an odd `--severity` list is `@effect/tsgo`'s to
+ * judge, in its own words and with its own exit code. Reading a value here
+ * never means validating it.
+ */
+export const splitDiagnosticsArgs = (args: readonly string[]): DiagnosticsInvocation => {
+  const forwarded: string[] = [];
+  const errors: string[] = [];
+  let analyzer = true;
+  let failOn: TsgoSeverity | 'none' | undefined;
+  let project: string | undefined;
+  let file: string | undefined;
+  let format: DiagnosticsFormat = 'pretty';
+  let severity: string | undefined;
+  let lspconfig: string | undefined;
+  let strict = false;
+  let progress = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+
+    if (arg === '--no-analyzer') {
+      analyzer = false;
+      continue;
+    }
+    if (arg === '--fail-on' || arg.startsWith('--fail-on=')) {
+      const raw = arg.startsWith('--fail-on=') ? arg.slice('--fail-on='.length) : args[++i];
+      const value = (raw ?? '').trim().toLowerCase();
+      if (value === 'none') failOn = 'none';
+      else if (value === 'error' || value === 'warning' || value === 'message') failOn = value;
+      else if (value === 'info') failOn = 'message';
+      else {
+        errors.push(
+          `Invalid value for --fail-on: ${String(raw)} (expected error, warning, message or none)`,
+        );
+      }
+      continue;
+    }
+
+    const prefix = VALUE_FLAGS.find((f) => arg === f || arg.startsWith(`${f}=`));
+    if (prefix !== undefined) {
+      forwarded.push(arg);
+      let value: string | undefined;
+      if (arg.startsWith(`${prefix}=`)) {
+        value = arg.slice(prefix.length + 1);
+      } else {
+        value = args[i + 1];
+        if (value !== undefined) {
+          forwarded.push(value);
+          i++;
+        }
+      }
+      if (prefix === '--project') project = value;
+      else if (prefix === '--file') file = value;
+      else if (prefix === '--severity') severity = value;
+      else if (prefix === '--lspconfig') lspconfig = value;
+      else if (value !== undefined && FORMATS.includes(value)) format = value as DiagnosticsFormat;
+      continue;
+    }
+
+    if (arg === '--strict') strict = true;
+    if (arg === '--progress') progress = true;
+    forwarded.push(arg);
+  }
+
+  return {
+    forwarded,
+    analyzer,
+    failOn,
+    project,
+    file,
+    format,
+    severity,
+    lspconfig,
+    strict,
+    progress,
+    errors,
+  };
+};
+
+/**
+ * `@effect/tsgo`'s own `--severity` semantics, ported exactly: entries are
+ * trimmed and lowercased, unrecognised ones are ignored, and a list with no
+ * recognised entry disables filtering rather than failing the run.
+ */
+export const parseSeverityFilter = (
+  value: string | undefined,
+): ReadonlySet<TsgoSeverity> | undefined => {
+  if (value === undefined || value === '') return undefined;
+  const result = new Set<TsgoSeverity>();
+  for (const item of value.split(',')) {
+    const level = item.trim().toLowerCase();
+    if (level === 'error' || level === 'warning' || level === 'message') result.add(level);
+  }
+  return result.size === 0 ? undefined : result;
+};
+
+// =============================================================================
+// Rendering the analyzer's own findings, in upstream's formats
+// =============================================================================
+
+/**
+ * GitHub workflow command escaping, exactly as `@effect/tsgo` applies it.
+ *
+ * Escaping `%` first is what stops a message containing a literal `%0A` from
+ * being decoded by the runner as a newline and ending the command early.
+ */
+const escapeWorkflowData = (value: string): string =>
+  value.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A');
+
+const GITHUB_COMMAND: Record<TsgoSeverity, string> = {
+  error: 'error',
+  warning: 'warning',
+  message: 'notice',
+};
+
+const COLOUR: Record<TsgoSeverity, string> = {
+  error: '[91m',
+  warning: '[93m',
+  message: '[96m',
+};
+
+/** Analyzer rules are labelled distinctly from upstream's `effect(name)`. */
+const label = (name: string): string => `effect-analyzer(${name})`;
+
+/**
+ * Render one analyzer finding the way `@effect/tsgo` renders its own, so a
+ * merged stream reads as a single report. `pretty` reproduces its source line
+ * and span underline.
+ */
+export const renderAnalyzerDiagnostic = (
+  d: Diagnostic,
+  format: DiagnosticsFormat,
+  source: string,
+): string => {
+  switch (format) {
+    case 'json':
+      return '';
+    case 'github-actions':
+      return `::${GITHUB_COMMAND[d.severity]} file=${d.file},line=${String(d.line)},col=${String(
+        d.column,
+      )},endLine=${String(d.endLine)},endColumn=${String(d.endColumn)},title=${
+        d.name
+      }::${escapeWorkflowData(d.message)}\n`;
+    case 'text':
+      return `${d.file}(${String(d.line)},${String(d.column)}): ${d.severity} ${label(d.name)}: ${
+        d.message
+      }\n`;
+    case 'pretty': {
+      const colour = COLOUR[d.severity];
+      const reset = '[0m';
+      const header = `${colour}${d.file}:${String(d.line)}:${String(d.column)} - ${
+        d.severity
+      } ${label(d.name)}:${reset} ${d.message}\n`;
+      const lines = source.split('\n');
+      if (d.line <= 0 || d.line > lines.length) return header;
+      const text = (lines[d.line - 1] ?? '').replace(/\r$/, '');
+      const underline =
+        ' '.repeat(Math.max(d.column - 1, 0)) + '~'.repeat(Math.max(d.endColumn - d.column, 1));
+      return `${header}\n${String(d.line)} ${text}\n  ${colour}${underline}${reset}\n\n`;
+    }
+  }
+};
+
+/**
+ * Whether `@effect/tsgo` actually produced a diagnostics report.
+ *
+ * It exits 1 for a missing target, an unsupported flag, unparseable
+ * `--lspconfig` and `--help` just as it does for a run that found errors, so
+ * the status alone cannot tell a failed invocation from a failing check. The
+ * report itself can: JSON mode parses to a `diagnostics` array, and every
+ * textual mode ends with the summary trailer. Without one, upstream's output
+ * and status are the entire answer — merging findings into a help screen, or
+ * letting `--fail-on` turn a usage error into a pass, would report a run that
+ * never happened as a clean one.
+ */
+export const producedReport = (stdout: string, format: DiagnosticsFormat): boolean => {
+  if (format === 'json') {
+    const start = stdout.indexOf('{');
+    if (start === -1) return false;
+    try {
+      const parsed = JSON.parse(stdout.slice(start)) as { diagnostics?: unknown };
+      return Array.isArray(parsed.diagnostics);
+    } catch {
+      return false;
+    }
+  }
+  return splitTrailer(stdout).trailer.length > 0;
+};
+
+/**
+ * Split upstream's textual output into the diagnostics it rendered and its
+ * trailing summary block, so analyzer findings can be appended to the former
+ * without disturbing a byte of it.
+ */
+export const splitTrailer = (
+  stdout: string,
+): { readonly body: string; readonly trailer: string } => {
+  const match =
+    /(?:Effect version per file:\n(?:  .*\n)*)?Checked \d+ files out of \d+ files\. \n\d+ errors, \d+ warnings and \d+ messages\.\n$/.exec(
+      stdout,
+    );
+  if (!match) return { body: stdout, trailer: '' };
+  return { body: stdout.slice(0, match.index), trailer: match[0] };
+};
+
+/** Rewrite upstream's counts line so it accounts for the analyzer's findings. */
+export const retotalTrailer = (trailer: string, ours: readonly Diagnostic[]): string => {
+  const match = /(\d+) errors, (\d+) warnings and (\d+) messages\.\n$/.exec(trailer);
+  if (!match) return trailer;
+  const count = (severity: TsgoSeverity): number =>
+    ours.filter((d) => d.severity === severity).length;
+  return (
+    trailer.slice(0, match.index) +
+    `${String(Number(match[1]) + count('error'))} errors, ` +
+    `${String(Number(match[2]) + count('warning'))} warnings and ` +
+    `${String(Number(match[3]) + count('message'))} messages.\n`
+  );
+};
+
+/**
+ * Splice analyzer findings into upstream's JSON.
+ *
+ * Its `diagnostics` array is preserved exactly as it came back — same entries,
+ * same order — and ours are appended after it, so a consumer relying on
+ * upstream's ordering still gets it.
+ */
+export const mergeJson = (stdout: string, ours: readonly Diagnostic[]): string => {
+  const start = stdout.indexOf('{');
+  if (start === -1) return stdout;
+  interface UpstreamJson {
+    diagnostics?: readonly Record<string, unknown>[];
+    files?: readonly unknown[];
+    summary?: Record<string, number>;
+  }
+  let parsed: UpstreamJson;
+  try {
+    parsed = JSON.parse(stdout.slice(start)) as UpstreamJson;
+  } catch {
+    return stdout;
+  }
+  const diagnostics = [
+    ...(parsed.diagnostics ?? []).map((d) => ({ ...d, source: 'tsgo' })),
+    ...ours,
+  ];
+  const count = (severity: TsgoSeverity): number =>
+    diagnostics.filter((d) => (d as { severity?: unknown }).severity === severity).length;
+  return `${JSON.stringify(
+    {
+      diagnostics,
+      ...(parsed.files === undefined ? {} : { files: parsed.files }),
+      summary: {
+        ...(parsed.summary ?? {}),
+        errors: count('error'),
+        warnings: count('warning'),
+        messages: count('message'),
+      },
+    },
+    null,
+    2,
+  )}\n`;
+};
+
+// =============================================================================
+// Running
+// =============================================================================
+
+/** Byte offset of a 1-indexed line and column within `source`. */
+const offsetOf = (source: string, line: number, column: number): number => {
+  let offset = 0;
+  for (let current = 1; current < line; current++) {
+    const next = source.indexOf('\n', offset);
+    if (next === -1) return offset;
+    offset = next + 1;
+  }
+  return offset + Math.max(0, column - 1);
+};
+
+interface AnalyzerFinding {
+  readonly diagnostic: Diagnostic;
+  readonly source: string;
+}
+
+/** Analyzer AST rules over the given files, in the upstream schema. */
+const analyzerDiagnostics = async (
+  files: readonly string[],
+  severity: ReadonlySet<TsgoSeverity> | undefined,
+): Promise<readonly AnalyzerFinding[]> => {
+  const out: AnalyzerFinding[] = [];
+  for (const file of files) {
+    let source: string;
+    try {
+      source = await readFile(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const issue of lintSourceCode(source, file).issues) {
+      const line = issue.location?.line ?? 1;
+      const column = issue.location?.column ?? 1;
+      const endLine = issue.location?.endLine ?? line;
+      const endColumn = issue.location?.endColumn ?? column;
+      const mapped: TsgoSeverity = issue.severity === 'info' ? 'message' : issue.severity;
+      if (severity !== undefined && !severity.has(mapped)) continue;
+      const start = offsetOf(source, line, column);
+      const end = offsetOf(source, endLine, endColumn);
+      out.push({
+        source,
+        diagnostic: {
+          file,
+          start,
+          length: Math.max(0, end - start),
+          line,
+          column,
+          endLine,
+          endColumn,
+          severity: mapped,
+          code: ANALYZER_DIAGNOSTIC_CODE,
+          name: issue.rule,
+          message: issue.message,
+          source: 'analyzer',
+        },
+      });
+    }
+  }
+  return out;
+};
+
+/** Highest severity upstream reported, read back from its own output. */
+const upstreamWorstSeverity = (stdout: string): number => {
+  const counts =
+    /"errors":\s*(\d+),\s*"warnings":\s*(\d+),\s*"messages":\s*(\d+)/.exec(stdout) ??
+    /(\d+) errors, (\d+) warnings and (\d+) messages\./.exec(stdout);
+  if (!counts) return 0;
+  if (Number(counts[1]) > 0) return SEVERITY_ORDER.error;
+  if (Number(counts[2]) > 0) return SEVERITY_ORDER.warning;
+  if (Number(counts[3]) > 0) return SEVERITY_ORDER.message;
+  return 0;
+};
+
+export interface DiagnosticsRunResult {
+  readonly output: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+export const runDiagnosticsCommand = async (
+  args: readonly string[],
+): Promise<DiagnosticsRunResult> => {
+  const invocation = splitDiagnosticsArgs(args);
+  if (invocation.errors.length > 0) throw new TsgoDiagnosticsError(invocation.errors.join('\n'));
+
+  // Forwarded exactly as given. `@effect/tsgo` reads the project's own
+  // `@effect/language-service` plugin options, so synthesising a `--lspconfig`
+  // here would replace the severities a project configured with rule defaults.
+  const tsgo = spawnTsgoDiagnostics(invocation.forwarded, {
+    inheritStderr: invocation.progress,
+  });
+
+  // Upstream did not produce a report: its output and its status are the whole
+  // answer, and nothing of ours belongs in them.
+  if (!producedReport(tsgo.stdout, invocation.format)) {
+    return { output: tsgo.stdout, stderr: tsgo.stderr, exitCode: tsgo.status };
+  }
+
+  // `--project` and `--file` together are a union upstream, not a narrowing.
+  const analyzerFiles = !invocation.analyzer
+    ? []
+    : [
+        ...new Set([
+          ...(invocation.project === undefined
+            ? []
+            : readTsgoProjectFiles(resolve(invocation.project))),
+          ...(invocation.file === undefined ? [] : [resolve(invocation.file)]),
+        ]),
+      ];
+
+  const findings = await analyzerDiagnostics(
+    analyzerFiles,
+    parseSeverityFilter(invocation.severity),
+  );
+  const ours = findings.map((f) => f.diagnostic);
+
+  const exitCode = ((): number => {
+    if (invocation.failOn === 'none') return 0;
+    if (invocation.failOn !== undefined) {
+      const worst = Math.max(
+        upstreamWorstSeverity(tsgo.stdout),
+        ...ours.map((d) => SEVERITY_ORDER[d.severity]),
+        0,
+      );
+      return worst >= SEVERITY_ORDER[invocation.failOn] ? 1 : 0;
+    }
+    // Upstream already decided about its own diagnostics under its own rule;
+    // only ours can add a failure it did not see.
+    const threshold = invocation.strict ? SEVERITY_ORDER.warning : SEVERITY_ORDER.error;
+    return Math.max(tsgo.status, ours.some((d) => SEVERITY_ORDER[d.severity] >= threshold) ? 1 : 0);
+  })();
+
+  // JSON is re-serialised even with nothing to add, so `source` is always
+  // present and the schema does not change shape with `--no-analyzer`. Entry
+  // order and every upstream field are preserved by the merge.
+  if (invocation.format === 'json') {
+    return { output: mergeJson(tsgo.stdout, ours), stderr: tsgo.stderr, exitCode };
+  }
+
+  // Every other format is upstream's own output, byte for byte, when we have
+  // nothing to contribute to it.
+  if (ours.length === 0) {
+    return { output: tsgo.stdout, stderr: tsgo.stderr, exitCode };
+  }
+
+  const { body, trailer } = splitTrailer(tsgo.stdout);
+  const rendered = findings
+    .map((f) => renderAnalyzerDiagnostic(f.diagnostic, invocation.format, f.source))
+    .join('');
+  return {
+    output: `${body}${rendered}${retotalTrailer(trailer, ours)}`,
+    stderr: tsgo.stderr,
+    exitCode,
+  };
+};

--- a/packages/effect-analyzer/src/cli-help.ts
+++ b/packages/effect-analyzer/src/cli-help.ts
@@ -13,6 +13,27 @@ export const HELP_TEXT = `
 effect-analyzer - Static analysis for Effect-TS
 
 Usage: effect-analyze [PATH] [options]
+       effect-analyze <command> [options]
+
+Commands (a drop-in replacement for the effect-tsgo CLI):
+  diagnostics              Effect language service diagnostics plus the analyzer's
+                           own rules, in one stream. Same flags as
+                           "effect-tsgo diagnostics", same exit codes:
+                             --project <tsconfig>   Project to check
+                             --file <path>          Check a single file
+                             --format <fmt>         json | pretty | text | github-actions
+                             --severity <list>      Filter: error,warning,message
+                             --strict               Also fail on warnings
+                             --progress             Narrate progress on stderr
+                             --list-files           Report Effect versions per file
+                             --fail-on <severity>   error | warning | message | none
+                             --lspconfig <json>     Inline plugin options override
+                             --no-analyzer          Language service diagnostics only
+                           One of --project or --file is required, as upstream.
+  setup                    Guided @effect/tsgo setup (forwarded)
+  config                   Interactive diagnostic severity picker (forwarded)
+  patch | unpatch          Manage the patched TypeScript/Oxlint binaries (forwarded)
+  get-exe-path             Print the Effect language service executable path (forwarded)
 
   PATH is optional and defaults to the current directory (.).
   When PATH is a directory: analyzes all TypeScript files and writes colocated
@@ -92,6 +113,9 @@ Options:
                            using the target project's TypeScript 7 installation
   --sarif                  Emit SARIF 2.1.0 output (for --lint-source)
   --baseline <file>        Compare findings against a baseline session/json file
+  --fail-on <severity>     Exit 1 when a finding is at or above error | warning | info
+                           (for --lint-source; omit for an advisory run that
+                           never changes the exit status)
   --fail-on-new            Exit non-zero when new findings exist vs baseline
   --require-suppression-reason  Require a reason after disable-next-line suppression comments
   --fail-on-stale-suppressions  Exit non-zero when disable-next-line suppressions are stale
@@ -125,6 +149,9 @@ Examples:
   effect-analyze ./program.ts --format json --output result.json
   effect-analyze ./program.ts --colocate   # Single file + write foo.effect-analysis.md
   effect-analyze ./src --lint-source --tsgo=tsconfig.json
+  effect-analyze ./src --lint-source --tsgo=tsconfig.json --fail-on=error
+  effect-analyze diagnostics --project tsconfig.json --format json
+  effect-analyze diagnostics --project tsconfig.json --format github-actions --strict
   effect-analyze ./src --lint-source --sarif -o findings.sarif
   effect-analyze ./src --lint-source --baseline ./.cache/effect-lint-baseline.json --fail-on-new
   effect-analyze ./src --lint-source --scorecard

--- a/packages/effect-analyzer/src/cli-mode-reports.ts
+++ b/packages/effect-analyzer/src/cli-mode-reports.ts
@@ -37,6 +37,7 @@ import {
 import {
   buildLintScorecard,
   compareAgainstBaseline,
+  exitCodeFor,
   runSourceLintScan,
   toSarif,
   type LintFinding,
@@ -137,6 +138,7 @@ export const runLintSourceMode = (
         staleSuppressions: scan.staleSuppressions.length,
         suppressionsMissingReason: scan.suppressionsMissingReason.length,
         baseline: baselineSummary,
+        tsgo: scan.tsgo,
       },
       data: dataPayload,
       findings: scan.findings,
@@ -190,6 +192,14 @@ export const runLintSourceMode = (
       );
     }
 
+    if (exitCodeFor(scan.findings, options.failOn) === 1) {
+      const gated = scan.findings.filter(
+        (f) => exitCodeFor([f], options.failOn) === 1,
+      );
+      return yield* cliFail(
+        `Findings at or above ${String(options.failOn)}: ${String(gated.length)}`,
+      );
+    }
     if (options.failOnNew && baselineSummary && baselineSummary.new > 0) {
       return yield* cliFail(`New findings detected: ${String(baselineSummary.new)}`);
     }

--- a/packages/effect-analyzer/src/cli-options.ts
+++ b/packages/effect-analyzer/src/cli-options.ts
@@ -9,6 +9,7 @@
 import { parseTsgoProjectArgument } from './tsgo-diagnostics';
 import { printHelp } from './cli-help';
 import type { CouplingIssueType, CouplingPriorityMap } from './agent-report';
+import type { FailOnSeverity } from './lint-session';
 
 export type MermaidDirection = 'TB' | 'LR' | 'BT' | 'RL';
 export type TestRunner = 'vitest' | 'jest' | 'mocha';
@@ -79,6 +80,7 @@ export interface CLIOptions {
   readonly failOnNew: boolean;
   readonly requireSuppressionReason: boolean;
   readonly failOnStaleSuppressions: boolean;
+  readonly failOn: FailOnSeverity | undefined;
   readonly serviceCycles: boolean;
   readonly bundleOutput: string | undefined;
   readonly scorecard: boolean;
@@ -218,6 +220,7 @@ export function parseArgs(args: readonly string[]): {
   let failOnNew = false;
   let requireSuppressionReason = false;
   let failOnStaleSuppressions = false;
+  let failOn: FailOnSeverity | undefined;
   let serviceCycles = false;
   let bundleOutput: string | undefined;
   let scorecard = false;
@@ -495,6 +498,13 @@ export function parseArgs(args: readonly string[]): {
       requireSuppressionReason = true;
     } else if (arg === '--fail-on-stale-suppressions') {
       failOnStaleSuppressions = true;
+    } else if (arg === '--fail-on' || arg.startsWith('--fail-on=')) {
+      const value = arg === '--fail-on' ? args[++i] : arg.slice('--fail-on='.length);
+      if (value === 'error' || value === 'warning' || value === 'info') {
+        failOn = value;
+      } else {
+        rejectValue('--fail-on', value);
+      }
     } else if (arg === '--service-cycles') {
       serviceCycles = true;
     } else if (arg === '--bundle-output') {
@@ -657,6 +667,7 @@ export function parseArgs(args: readonly string[]): {
     failOnNew,
     requireSuppressionReason,
     failOnStaleSuppressions,
+    failOn,
     serviceCycles,
     bundleOutput,
     scorecard,

--- a/packages/effect-analyzer/src/cli.diagnostics.test.ts
+++ b/packages/effect-analyzer/src/cli.diagnostics.test.ts
@@ -1,0 +1,578 @@
+/**
+ * `effect-analyze diagnostics` — a drop-in replacement for
+ * `effect-tsgo diagnostics` that also reports the analyzer's own rules.
+ *
+ * These tests pin the contract that makes it safe to swap: the same flags, the
+ * same exit-code behaviour, and one merged stream where every entry says which
+ * checker produced it.
+ */
+
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+/** A floating Effect (`floatingEffect`) plus a barrel import (analyzer rule). */
+const SOURCE = `import { Effect } from 'effect';
+
+export const program = Effect.gen(function* () {
+  Effect.succeed(1);
+  return yield* Effect.succeed(2);
+});
+`;
+
+const withProject = (
+  fn: (root: string, tsconfig: string) => void,
+  diagnosticSeverity?: Record<string, string>,
+) => {
+  const root = mkdtempSync(join(REPO_ROOT, '.tmp-tsgo-diag-'));
+  try {
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'program.ts'), SOURCE, 'utf8');
+    const plugin = diagnosticSeverity
+      ? { name: '@effect/language-service', diagnosticSeverity }
+      : { name: '@effect/language-service' };
+    const tsconfig = join(root, 'tsconfig.json');
+    writeFileSync(
+      tsconfig,
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+          plugins: [plugin],
+        },
+        include: ['src/**/*.ts'],
+      }),
+      'utf8',
+    );
+    fn(root, tsconfig);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+const run = (args: readonly string[]) =>
+  spawnSync(process.execPath, ['dist/cli.js', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+interface Entry {
+  readonly name: string;
+  readonly source: string;
+  readonly severity: string;
+  readonly code: number;
+}
+
+const parse = (stdout: string): readonly Entry[] => {
+  const start = stdout.indexOf('{');
+  const parsed = JSON.parse(stdout.slice(start)) as { diagnostics?: readonly Entry[] };
+  return parsed.diagnostics ?? [];
+};
+
+describe('effect-analyze diagnostics', () => {
+  it('reports language service and analyzer findings in one stream', () => {
+    withProject((_root, tsconfig) => {
+      const result = run(['diagnostics', '--project', tsconfig, '--format', 'json']);
+      const entries = parse(result.stdout);
+
+      const sources = new Set(entries.map((e) => e.source));
+      expect(sources).toContain('tsgo');
+      expect(sources).toContain('analyzer');
+      expect(entries.find((e) => e.name === 'floatingEffect')?.code).toBeGreaterThanOrEqual(
+        377_000,
+      );
+      // Analyzer entries carry a code outside the Effect range, so a consumer
+      // filtering on 377xxx keeps seeing exactly what effect-tsgo showed it.
+      expect(entries.find((e) => e.source === 'analyzer')?.code).toBe(0);
+    });
+  });
+
+  it('filters by severity the way effect-tsgo does', () => {
+    withProject(
+      (_root, tsconfig) => {
+        const result = run([
+          'diagnostics',
+          '--project',
+          tsconfig,
+          '--format',
+          'json',
+          '--severity',
+          'error',
+        ]);
+        const severities = new Set(parse(result.stdout).map((e) => e.severity));
+        expect(severities).toEqual(new Set(['error']));
+      },
+      { floatingEffect: 'error' },
+    );
+  });
+
+  // effect-tsgo exits 1 when any error is present, and --strict additionally
+  // counts warnings. A drop-in replacement has to agree on both.
+  it('exits 1 on an error, matching effect-tsgo', () => {
+    withProject(
+      (_root, tsconfig) => {
+        const result = run(['diagnostics', '--project', tsconfig, '--format', 'json']);
+        expect(result.status).toBe(1);
+      },
+      { floatingEffect: 'error' },
+    );
+  });
+
+  it('ignores warnings unless --strict, matching effect-tsgo', () => {
+    withProject(
+      (_root, tsconfig) => {
+        expect(run(['diagnostics', '--project', tsconfig, '--format', 'json']).status).toBe(0);
+        expect(
+          run(['diagnostics', '--project', tsconfig, '--format', 'json', '--strict']).status,
+        ).toBe(1);
+      },
+      { floatingEffect: 'warning' },
+    );
+  });
+
+  it('can be made advisory-only with --fail-on=none', () => {
+    withProject(
+      (_root, tsconfig) => {
+        const result = run([
+          'diagnostics',
+          '--project',
+          tsconfig,
+          '--format',
+          'json',
+          '--fail-on=none',
+        ]);
+        expect(result.status).toBe(0);
+      },
+      { floatingEffect: 'error' },
+    );
+  });
+
+  it('emits GitHub workflow commands for CI', () => {
+    withProject(
+      (_root, tsconfig) => {
+        const result = run([
+          'diagnostics',
+          '--project',
+          tsconfig,
+          '--format',
+          'github-actions',
+        ]);
+        // GitHub workflow command syntax, with the rule as the annotation
+        // title so the Effect rule name shows up in the PR annotation.
+        expect(result.stdout).toMatch(
+          /^::error file=.+program\.ts,line=\d+,col=\d+,endLine=\d+,endColumn=\d+,title=floatingEffect::/m,
+        );
+      },
+      { floatingEffect: 'error' },
+    );
+  });
+});
+
+describe('effect-analyze tsgo passthrough commands', () => {
+  const tsgo = (args: readonly string[]) =>
+    spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, 'node_modules', '@effect', 'tsgo', 'dist', 'effect-tsgo.cjs'), ...args],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+
+  it('get-exe-path answers exactly as effect-tsgo does', () => {
+    const ours = run(['get-exe-path']);
+    const theirs = tsgo(['get-exe-path']);
+    expect(ours.status).toBe(theirs.status);
+    expect(ours.stdout.trim()).toBe(theirs.stdout.trim());
+    expect(ours.stdout.trim().length).toBeGreaterThan(0);
+  });
+
+  it('forwards flags to the proxied command', () => {
+    // `config` is the interactive rule picker, so --help is the observable,
+    // side-effect-free way to prove the flag reached effect-tsgo.
+    const ours = run(['config', '--help']);
+    const theirs = tsgo(['config', '--help']);
+    expect(ours.status).toBe(theirs.status);
+    expect(ours.stdout).toContain('interactive rule picker');
+    expect(ours.stdout).toBe(theirs.stdout);
+  });
+
+  it('still treats a path argument as a path, not a subcommand', () => {
+    withProject((root) => {
+      const result = run([join(root, 'src'), '--lint-source']);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('"findings"');
+    });
+  });
+});
+
+/**
+ * These hold `effect-analyze diagnostics` against the native binary on the same
+ * inputs. Anything that differs is a reason a project cannot swap the two.
+ */
+describe('effect-analyze diagnostics / effect-tsgo parity', () => {
+  /**
+   * A project configured the way a real one is: the language service enabled
+   * through an `@effect/language-service` plugin entry, with the package's own
+   * lint fixture copied in for a rich set of diagnostics.
+   *
+   * Parity is measured here rather than against this package's own tsconfig,
+   * which has no plugin entry — both binaries would check nothing and every
+   * comparison would hold vacuously. Neither side is passed `--lspconfig`:
+   * upstream reads the configuration from the project, which is the whole point.
+   */
+  // Created in beforeAll, not in the describe body: the body is evaluated even
+  // when a filter selects no test here, and afterAll would then never run to
+  // clean it up.
+  let PROJECT = '';
+  let FIXTURE = '';
+  let PROJECT_TSCONFIG = '';
+
+  beforeAll(() => {
+    PROJECT = mkdtempSync(join(REPO_ROOT, '.tmp-tsgo-parity-'));
+    FIXTURE = join(PROJECT, 'src', 'lint-issues.ts');
+    PROJECT_TSCONFIG = join(PROJECT, 'tsconfig.json');
+    mkdirSync(join(PROJECT, 'src'), { recursive: true });
+    writeFileSync(
+      FIXTURE,
+      readFileSync(join(REPO_ROOT, 'src', '__fixtures__', 'lint-issues.ts'), 'utf8'),
+      'utf8',
+    );
+    writeFileSync(
+      join(PROJECT, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+          plugins: [{ name: '@effect/language-service' }],
+        },
+        include: ['src/**/*.ts'],
+      }),
+      'utf8',
+    );
+  });
+
+  afterAll(() => {
+    if (PROJECT !== '') rmSync(PROJECT, { recursive: true, force: true });
+  });
+
+  const native = (args: readonly string[]) =>
+    spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, 'node_modules', '@effect', 'tsgo', 'dist', 'effect-tsgo.cjs'), ...args],
+      { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+
+  const tsgoOnly = (stdout: string) => {
+    const parsed = JSON.parse(stdout.slice(stdout.indexOf('{'))) as {
+      diagnostics: readonly Record<string, unknown>[];
+      summary: Record<string, number>;
+    };
+    return parsed;
+  };
+
+  it('checks the single file given to --file, not the whole project', () => {
+    const ours = tsgoOnly(
+      run(['diagnostics', '--file', FIXTURE, '--format', 'json', '--no-analyzer']).stdout,
+    );
+    const theirs = tsgoOnly(
+      native(['diagnostics', '--file', FIXTURE, '--format', 'json']).stdout,
+    );
+
+    // One file checked, not the 154 in the project — and not zero, which is
+    // what a single-file run reports without the plugin options.
+    expect(ours.summary.filesChecked).toBe(1);
+    expect(ours.summary.totalFiles).toBe(1);
+    expect(ours.summary).toEqual(theirs.summary);
+    // Identical to upstream once the one additive field is removed.
+    const withoutSource = ours.diagnostics.map(({ source, ...rest }) => {
+      expect(source).toBe('tsgo');
+      return rest;
+    });
+    expect(withoutSource).toEqual(theirs.diagnostics);
+  }, 300_000);
+
+  it('emits the upstream diagnostic schema', () => {
+    const ours = tsgoOnly(
+      run(['diagnostics', '--file', FIXTURE, '--format', 'json', '--no-analyzer']).stdout,
+    );
+    const entry = ours.diagnostics[0]!;
+    // Upstream field names and value domain, plus `source` as an addition.
+    expect(Object.keys(entry).sort()).toEqual(
+      [
+        'code', 'column', 'endColumn', 'endLine', 'file', 'length', 'line',
+        'message', 'name', 'severity', 'source', 'start',
+      ].sort(),
+    );
+    expect(['error', 'warning', 'message']).toContain(entry['severity']);
+  }, 300_000);
+
+  it('fails like effect-tsgo when neither --file nor --project is given', () => {
+    const ours = run(['diagnostics', '--format', 'json']);
+    const theirs = native(['diagnostics', '--format', 'json']);
+    expect(ours.status).toBe(theirs.status);
+    expect(ours.status).toBe(1);
+    expect(`${ours.stdout}${ours.stderr}`).toContain('No files to check');
+  }, 300_000);
+
+  it('forwards --progress and --list-files to the language service', () => {
+    // --progress narrates to stderr and must not corrupt stdout.
+    const progress = run(['diagnostics', '--file', FIXTURE, '--format', 'json', '--progress']);
+    expect(() => tsgoOnly(progress.stdout)).not.toThrow();
+
+    // --list-files must reach @effect/tsgo rather than being silently dropped;
+    // the following test asserts the file metadata it returns.
+    const ours = run(['diagnostics', '--file', FIXTURE, '--format', 'json', '--list-files']);
+    const theirs = native(['diagnostics', '--file', FIXTURE, '--format', 'json', '--list-files']);
+    expect(ours.status).toBe(theirs.status);
+  }, 300_000);
+
+  it('escapes GitHub workflow command data the way upstream does', () => {
+    const ours = run([
+      'diagnostics', '--file', FIXTURE, '--format', 'github-actions', '--no-analyzer',
+    ]);
+    const theirs = native([
+      'diagnostics', '--file', FIXTURE, '--format', 'github-actions',
+    ]);
+    const commands = (out: string) =>
+      out.split('\n').filter((l) => l.startsWith('::')).join('\n');
+    expect(commands(ours.stdout)).toBe(commands(theirs.stdout));
+    // A message may not smuggle a newline through an unescaped percent sign.
+    expect(commands(ours.stdout)).not.toMatch(/[^%]%0A/);
+  }, 300_000);
+
+  it('renders pretty exactly as effect-tsgo does', () => {
+    const ours = run(['diagnostics', '--file', FIXTURE, '--format', 'pretty', '--no-analyzer']);
+    const theirs = native([
+      'diagnostics', '--file', FIXTURE, '--format', 'pretty',
+    ]);
+    expect(ours.stdout).toBe(theirs.stdout);
+    // Guards the comparison itself: pretty prints a source line and underline
+    // per diagnostic, so a header-only renderer would be far shorter.
+    expect(ours.stdout.split('\n').length).toBeGreaterThan(20);
+  }, 300_000);
+
+  it('preserves upstream diagnostic order across a whole project', () => {
+    const ours = tsgoOnly(
+      run(['diagnostics', '--project', PROJECT_TSCONFIG, '--format', 'json', '--no-analyzer'])
+        .stdout,
+    );
+    const theirs = tsgoOnly(
+      native(['diagnostics', '--project', PROJECT_TSCONFIG, '--format', 'json'])
+        .stdout,
+    );
+    expect(ours.diagnostics.map((d) => `${String(d['file'])}:${String(d['line'])}:${String(d['name'])}`)).toEqual(
+      theirs.diagnostics.map((d) => `${String(d['file'])}:${String(d['line'])}:${String(d['name'])}`),
+    );
+  }, 300_000);
+
+  it('applies effect-tsgo\'s own --severity semantics', () => {
+    // Upstream lowercases entries, ignores unrecognised ones, and filters not
+    // at all when nothing in the list is recognised.
+    for (const value of ['ERROR', 'warning,bogus', 'nonsense']) {
+      const ours = run(['diagnostics', '--file', FIXTURE, '--format', 'json', '--severity', value]);
+      const theirs = native([
+        'diagnostics', '--file', FIXTURE, '--format', 'json', '--severity', value,
+      ]);
+      expect(`${value}:${String(ours.status)}`).toBe(`${value}:${String(theirs.status)}`);
+    }
+  }, 300_000);
+
+  it('returns the per-file Effect versions for --list-files', () => {
+    const parsed = tsgoOnly(
+      run([
+        'diagnostics', '--file', FIXTURE, '--format', 'json', '--list-files', '--no-analyzer',
+      ]).stdout,
+    ) as unknown as { files?: readonly Record<string, string>[] };
+    expect(parsed.files).toEqual([
+      {
+        file: resolve(REPO_ROOT, FIXTURE),
+        detectedEffect: 'v4',
+        supportedEffect: 'v4',
+      },
+    ]);
+  }, 300_000);
+
+  it('renders text exactly as effect-tsgo does', () => {
+    const ours = run(['diagnostics', '--file', FIXTURE, '--format', 'text', '--no-analyzer']);
+    const theirs = native([
+      'diagnostics', '--file', FIXTURE, '--format', 'text',
+    ]);
+    expect(ours.stdout).toBe(theirs.stdout);
+  }, 300_000);
+});
+
+/**
+ * When `@effect/tsgo` does not produce a diagnostics report — no target, a bad
+ * flag, unparseable `--lspconfig`, `--help` — its stdout, stderr and status are
+ * the whole answer. Overriding that status or appending analyzer findings to it
+ * turns a failed invocation into a passing, plausible-looking run.
+ */
+describe('effect-analyze diagnostics / upstream invocation failures', () => {
+  const FIXTURE = 'src/__fixtures__/lint-issues.ts';
+
+  const native = (args: readonly string[]) =>
+    spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, 'node_modules', '@effect', 'tsgo', 'dist', 'effect-tsgo.cjs'), ...args],
+      { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+
+  const cases: readonly (readonly [string, readonly string[]])[] = [
+    ['no target', ['diagnostics']],
+    ['unsupported --format', ['diagnostics', '--file', FIXTURE, '--format', 'bogus']],
+    [
+      'unparseable --lspconfig',
+      ['diagnostics', '--file', FIXTURE, '--format', 'json', '--lspconfig', 'notjson'],
+    ],
+    ['--help', ['diagnostics', '--file', FIXTURE, '--help']],
+  ];
+
+  it.each(cases)('reports a failed invocation faithfully: %s', (_name, args) => {
+    for (const extra of [[], ['--fail-on=none'], ['--fail-on=warning']]) {
+      const ours = run([...args, ...extra]);
+      const theirs = native([...args]);
+      // A failed invocation is never turned into a success by our own gate.
+      expect(`${String(extra)}:${String(ours.status)}`).toBe(`${String(extra)}:${String(theirs.status)}`);
+      // ...and nothing of ours is appended to what it printed.
+      expect(ours.stdout).not.toContain('effect-analyzer(');
+      expect(ours.stdout).not.toContain('"source": "analyzer"');
+    }
+  }, 300_000);
+
+  it('analyzes the union of --project and --file, as effect-tsgo does', () => {
+    // A project of one file, plus a second file the tsconfig does not include.
+    // Upstream unions the two targets; narrowing to the file would check one.
+    const root = mkdtempSync(join(REPO_ROOT, '.tmp-tsgo-union-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      mkdirSync(join(root, 'extra'), { recursive: true });
+      writeFileSync(join(root, 'src', 'inside.ts'), SOURCE, 'utf8');
+      writeFileSync(join(root, 'extra', 'outside.ts'), SOURCE, 'utf8');
+      const tsconfig = join(root, 'tsconfig.json');
+      writeFileSync(
+        tsconfig,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            strict: true,
+            skipLibCheck: true,
+            noEmit: true,
+            plugins: [{ name: '@effect/language-service' }],
+          },
+          include: ['src/**/*.ts'],
+        }),
+        'utf8',
+      );
+
+      const args = [
+        '--project', tsconfig, '--file', join(root, 'extra', 'outside.ts'), '--format', 'json',
+      ];
+      const ours = run(['diagnostics', ...args, '--no-analyzer']);
+      const parsed = JSON.parse(ours.stdout.slice(ours.stdout.indexOf('{'))) as {
+        diagnostics: readonly Record<string, unknown>[];
+        summary: Record<string, number>;
+      };
+      // Both targets are in scope — that is the union. Upstream checks only the
+      // one whose project enables the language service, and we report what it
+      // reported rather than a number of our own.
+      expect(parsed.summary['totalFiles']).toBe(2);
+      const theirs = JSON.parse(
+        native(['diagnostics', ...args]).stdout.slice(
+          native(['diagnostics', ...args]).stdout.indexOf('{'),
+        ),
+      ) as { summary: Record<string, number> };
+      expect(parsed.summary).toEqual(theirs.summary);
+
+      // Our own AST rules need no plugin, so they cover both halves.
+      const withAnalyzer = JSON.parse(
+        run(['diagnostics', ...args]).stdout.slice(run(['diagnostics', ...args]).stdout.indexOf('{')),
+      ) as { diagnostics: readonly Record<string, unknown>[] };
+
+      const analyzed = new Set(
+        withAnalyzer.diagnostics
+          .filter((d) => d['source'] === 'analyzer')
+          .map((d) => String(d['file'])),
+      );
+      expect([...analyzed].some((f) => f.endsWith('inside.ts'))).toBe(true);
+      expect([...analyzed].some((f) => f.endsWith('outside.ts'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 300_000);
+});
+
+/**
+ * The project's own plugin configuration must reach `@effect/tsgo` untouched.
+ *
+ * This regressed once: the wrapper looked for a plugin named `@effect/tsgo`,
+ * never found the canonical `@effect/language-service`, and forwarded
+ * `--lspconfig {}` — replacing every configured severity with the rule
+ * defaults, silently. Fixtures using the same wrong name hid it.
+ */
+describe('effect-analyze diagnostics / project configuration', () => {
+  const withConfiguredProject = (
+    diagnosticSeverity: Record<string, string>,
+    fn: (tsconfig: string) => void,
+  ) => {
+    const root = mkdtempSync(join(REPO_ROOT, '.tmp-tsgo-cfg-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(join(root, 'src', 'program.ts'), SOURCE, 'utf8');
+      const tsconfig = join(root, 'tsconfig.json');
+      writeFileSync(
+        tsconfig,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            strict: true,
+            skipLibCheck: true,
+            noEmit: true,
+            plugins: [{ name: '@effect/language-service', diagnosticSeverity }],
+          },
+          include: ['src/**/*.ts'],
+        }),
+        'utf8',
+      );
+      fn(tsconfig);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  const floatingEffectSeverities = (stdout: string): readonly string[] => {
+    const parsed = JSON.parse(stdout.slice(stdout.indexOf('{'))) as {
+      diagnostics: readonly { severity: string; name: string }[];
+    };
+    return parsed.diagnostics.filter((d) => d.name === 'floatingEffect').map((d) => d.severity);
+  };
+
+  it('honours a configured severity that differs from the rule default', () => {
+    // floatingEffect defaults to error, so `warning` here can only come from
+    // the project's own configuration reaching the language service.
+    withConfiguredProject({ floatingEffect: 'warning' }, (tsconfig) => {
+      const ours = run(['diagnostics', '--project', tsconfig, '--format', 'json', '--no-analyzer']);
+      expect(floatingEffectSeverities(ours.stdout)).toEqual(['warning']);
+    });
+  }, 300_000);
+
+  it('turns a rule off when the project turns it off', () => {
+    withConfiguredProject({ floatingEffect: 'off' }, (tsconfig) => {
+      const ours = run(['diagnostics', '--project', tsconfig, '--format', 'json', '--no-analyzer']);
+      expect(floatingEffectSeverities(ours.stdout)).toEqual([]);
+    });
+  }, 300_000);
+});

--- a/packages/effect-analyzer/src/cli.stdout-flush.test.ts
+++ b/packages/effect-analyzer/src/cli.stdout-flush.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The CLI exits with `process.exit`, which discards whatever is still queued on
+ * a piped stdout. Any JSON report larger than the pipe buffer was therefore
+ * truncated mid-string — valid-looking output, unparseable, no error, non-zero
+ * chance a consumer treats the short read as the whole report.
+ *
+ * Redirecting to a file hid it, so only a piped run reproduces it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+const run = (args: readonly string[]) =>
+  spawnSync(process.execPath, ['dist/cli.js', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+
+describe('piped stdout', () => {
+  it('writes a complete report when stdout is a pipe', () => {
+    // The analyzer's own src is far larger than the 64KB pipe buffer.
+    const result = run(['src', '--lint-source']);
+    expect(result.status).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(200_000);
+    expect(() => JSON.parse(result.stdout) as unknown).not.toThrow();
+  }, 300_000);
+
+  it('writes complete diagnostics when stdout is a pipe', () => {
+    const result = run(['diagnostics', '--project', 'tsconfig.json', '--format', 'json']);
+    expect(result.stdout.length).toBeGreaterThan(64 * 1024);
+    expect(() => JSON.parse(result.stdout) as unknown).not.toThrow();
+  }, 300_000);
+});

--- a/packages/effect-analyzer/src/cli.ts
+++ b/packages/effect-analyzer/src/cli.ts
@@ -20,6 +20,11 @@ import { analyzeStateMachines } from './state-machine';
 import { runWatchMode } from './watch-mode';
 import { cliFail, cliTry, resolveCliPath } from './cli-support';
 import { parseArgs } from './cli-options';
+import {
+  isProxiedTsgoCommand,
+  proxyTsgoCommand,
+  runDiagnosticsCommand,
+} from './cli-diagnostics';
 import { computeStateMachineCoverage } from './state-machine-coverage';
 import { renderStatechartsMermaid } from './output/mermaid-statechart';
 import { analyzeProject } from './project-analyzer';
@@ -53,6 +58,26 @@ import { detectServiceCycles } from './service-cycles';
 
 const main = Effect.gen(function* () {
   const args = process.argv.slice(2);
+
+  // Subcommands are matched before flag parsing so `effect-analyze` can stand in
+  // for `effect-tsgo` one-for-one.
+  const [subcommand, ...subcommandArgs] = args;
+  if (subcommand !== undefined && isProxiedTsgoCommand(subcommand)) {
+    process.exitCode = yield* cliTry(() => Promise.resolve(proxyTsgoCommand(subcommand, subcommandArgs)));
+    return Exit.succeed(undefined);
+  }
+  if (subcommand === 'diagnostics') {
+    const result = yield* cliTry(() => runDiagnosticsCommand(subcommandArgs));
+    // Written raw: this is effect-tsgo's own output, and Console.log would add
+    // a newline it did not emit.
+    yield* Effect.sync(() => {
+      process.stdout.write(result.output);
+      if (result.stderr.length > 0) process.stderr.write(result.stderr);
+    });
+    process.exitCode = result.exitCode;
+    return Exit.succeed(undefined);
+  }
+
   const { pathArg, options, errors: argErrors } = parseArgs(args);
 
   if (argErrors.length > 0) {
@@ -248,6 +273,21 @@ const main = Effect.gen(function* () {
   ),
 );
 
+/**
+ * Exit once stdout has drained.
+ *
+ * `process.exit` discards data still queued on a pipe, which silently truncated
+ * every JSON report larger than the pipe buffer. Writing to a file hid it
+ * because file writes complete synchronously.
+ */
+const exitWhenFlushed = (code: number): void => {
+  process.exitCode = code;
+  if (process.stdout.writableLength === 0) {
+    process.exit(code);
+  }
+  process.stdout.once('drain', () => process.exit(code));
+};
+
 // Run the program
 Effect.runPromise(main).then(
   (exit) => {
@@ -255,11 +295,11 @@ Effect.runPromise(main).then(
       // Already reported by the handler above. Stringifying the Cause here put
       // `{"_id":"Cause","failures":[...]}` in front of users who have no reason
       // to know the CLI is written in Effect.
-      process.exit(1);
+      exitWhenFlushed(1);
       return;
     }
     // Respect an exit code set during the run (e.g. coverage CI gate).
-    process.exit(process.exitCode ?? 0);
+    exitWhenFlushed(Number(process.exitCode ?? 0));
   },
   (err: unknown) => {
     const message =
@@ -267,6 +307,6 @@ Effect.runPromise(main).then(
     if (message) {
       console.error(`Error: ${message}`);
     }
-    process.exit(1);
+    exitWhenFlushed(1);
   },
 );

--- a/packages/effect-analyzer/src/cli.tsgo.test.ts
+++ b/packages/effect-analyzer/src/cli.tsgo.test.ts
@@ -26,7 +26,7 @@ const TSCONFIG = {
     strict: true,
     skipLibCheck: true,
     noEmit: true,
-    plugins: [{ name: '@effect/tsgo' }],
+    plugins: [{ name: '@effect/language-service' }],
   },
   include: ['src/**/*.ts'],
 };
@@ -35,19 +35,36 @@ interface Finding {
   readonly rule: string;
   readonly filePath: string;
   readonly line: number;
+  readonly code?: number;
+  readonly source?: string;
+  readonly severity?: string;
 }
 
 /**
  * The temp project lives inside the package so `effect`, `typescript` and
  * `@effect/tsgo` resolve through the normal parent-directory walk.
  */
-const withProject = (fn: (dir: string, tsconfig: string) => void) => {
+const withProject = (
+  fn: (dir: string, tsconfig: string) => void,
+  diagnosticSeverity?: Record<string, string>,
+) => {
   const root = mkdtempSync(join(REPO_ROOT, '.tmp-tsgo-cli-'));
   try {
     mkdirSync(join(root, 'src'), { recursive: true });
     writeFileSync(join(root, 'src', 'program.ts'), SOURCE, 'utf8');
     const tsconfig = join(root, 'tsconfig.json');
-    writeFileSync(tsconfig, JSON.stringify(TSCONFIG, null, 2), 'utf8');
+    const plugin = diagnosticSeverity
+      ? { name: '@effect/language-service', diagnosticSeverity }
+      : { name: '@effect/language-service' };
+    writeFileSync(
+      tsconfig,
+      JSON.stringify(
+        { ...TSCONFIG, compilerOptions: { ...TSCONFIG.compilerOptions, plugins: [plugin] } },
+        null,
+        2,
+      ),
+      'utf8',
+    );
     fn(join(root, 'src'), tsconfig);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -85,6 +102,25 @@ describe('cli --lint-source --tsgo', () => {
     });
   });
 
+  it('tells language-service findings apart from the analyzer’s own', () => {
+    withProject((srcDir, tsconfig) => {
+      const findings = parseFindings(
+        runLint([srcDir, '--lint-source', '--tsgo', tsconfig]).stdout,
+      );
+
+      const floating = findings.find((f) => f.rule === 'floatingEffect');
+      expect(floating?.source).toBe('tsgo');
+      // Effect language service diagnostics occupy the 377xxx code range, so an
+      // agent can prove a finding is advisory rather than a type-checker error.
+      expect(floating?.code).toBeGreaterThanOrEqual(377_000);
+      expect(floating?.code).toBeLessThan(378_000);
+
+      const builtIn = findings.find((f) => f.rule === 'barrel-import-from-effect');
+      expect(builtIn?.source).toBe('analyzer');
+      expect(builtIn?.code).toBeUndefined();
+    });
+  });
+
   it('reports only the built-in rules without --tsgo', () => {
     withProject((srcDir) => {
       const result = runLint([srcDir, '--lint-source']);
@@ -94,6 +130,79 @@ describe('cli --lint-source --tsgo', () => {
       expect(rules.has('floatingEffect')).toBe(false);
       // ...but the source linter still runs.
       expect(rules.has('barrel-import-from-effect')).toBe(true);
+    });
+  });
+});
+
+describe('cli --lint-source --fail-on', () => {
+  it('leaves the exit status alone when no gate is requested', () => {
+    withProject(
+      (srcDir, tsconfig) => {
+        const result = runLint([srcDir, '--lint-source', '--tsgo', tsconfig]);
+        // Advisory-only runs must not change the exit status, even with an
+        // error-severity diagnostic present, or agents cannot tell an advisory
+        // run apart from a broken one.
+        expect(result.status).toBe(0);
+        const severities = parseFindings(result.stdout).map((f) => f.severity);
+        expect(severities).toContain('error');
+      },
+      { floatingEffect: 'error' },
+    );
+  });
+
+  it('exits 1 when a finding reaches the requested severity', () => {
+    withProject(
+      (srcDir, tsconfig) => {
+        const result = runLint([srcDir, '--lint-source', '--tsgo', tsconfig, '--fail-on=error']);
+        expect(result.status).toBe(1);
+      },
+      { floatingEffect: 'error' },
+    );
+  });
+
+  it('exits 0 when every finding is below the requested severity', () => {
+    withProject(
+      (srcDir, tsconfig) => {
+        const result = runLint([srcDir, '--lint-source', '--tsgo', tsconfig, '--fail-on=error']);
+        expect(result.status).toBe(0);
+      },
+      { floatingEffect: 'warning' },
+    );
+  });
+});
+
+describe('cli --lint-source --tsgo coverage', () => {
+  /** A project where the tsconfig covers `src/` but not `extra/`. */
+  const withPartialProject = (fn: (root: string, tsconfig: string) => void) => {
+    const root = mkdtempSync(join(REPO_ROOT, '.tmp-tsgo-cov-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      mkdirSync(join(root, 'extra'), { recursive: true });
+      writeFileSync(join(root, 'src', 'program.ts'), SOURCE, 'utf8');
+      writeFileSync(join(root, 'extra', 'other.ts'), SOURCE, 'utf8');
+      const tsconfig = join(root, 'tsconfig.json');
+      writeFileSync(tsconfig, JSON.stringify(TSCONFIG, null, 2), 'utf8');
+      fn(root, tsconfig);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  it('reports which scanned files the language service never checked', () => {
+    withPartialProject((root, tsconfig) => {
+      const result = runLint([root, '--lint-source', '--tsgo', tsconfig]);
+      const start = result.stdout.indexOf('{');
+      const envelope = JSON.parse(result.stdout.slice(start)) as {
+        summary?: { tsgo?: { filesChecked?: number; unchecked?: readonly string[] } };
+      };
+
+      // extra/other.ts is linted by our AST rules but outside the tsconfig, so
+      // its tsgo diagnostics silently never existed. A partial check must not
+      // be reportable as a full one.
+      expect(envelope.summary?.tsgo?.filesChecked).toBe(1);
+      expect(envelope.summary?.tsgo?.unchecked).toEqual([
+        join(root, 'extra', 'other.ts'),
+      ]);
     });
   });
 });

--- a/packages/effect-analyzer/src/lint-session.test.ts
+++ b/packages/effect-analyzer/src/lint-session.test.ts
@@ -1,5 +1,79 @@
 import { describe, expect, it } from 'vitest';
-import { buildLintScorecard, compareAgainstBaseline, toSarif } from './lint-session';
+import {
+  buildLintScorecard,
+  compareAgainstBaseline,
+  exitCodeFor,
+  fingerprintOf,
+  toSarif,
+} from './lint-session';
+
+describe('finding fingerprints', () => {
+  it('matches the fingerprint earlier releases wrote into baselines', () => {
+    // Captured from the pre-`source` implementation: sha256 of
+    // filePath|line|column|rule|severity|message|suggestion, first 20 chars.
+    // A baseline written by an earlier release must still match, or --fail-on-new
+    // reports every existing finding as new after an upgrade.
+    expect(
+      fingerprintOf({
+        filePath: '/tmp/a.ts',
+        line: 7,
+        column: 3,
+        rule: 'floatingEffect',
+        severity: 'error',
+        message: 'This Effect is neither yielded nor assigned.',
+        suggestion: undefined,
+        source: 'tsgo',
+      }),
+    ).toBe('6bf628ba0d41a61c62c9');
+  });
+
+  it('does not let the reporting checker change a finding’s identity', () => {
+    const base = {
+      filePath: '/tmp/a.ts',
+      line: 7,
+      column: 3,
+      rule: 'floatingEffect',
+      severity: 'error' as const,
+      message: 'm',
+      suggestion: undefined,
+    };
+    expect(fingerprintOf({ ...base, source: 'tsgo' })).toBe(
+      fingerprintOf({ ...base, source: 'analyzer' }),
+    );
+  });
+});
+
+describe('exitCodeFor', () => {
+  const at = (severity: 'error' | 'warning' | 'info') => ({
+    filePath: '/tmp/a.ts',
+    rule: 'r',
+    severity,
+    message: 'm',
+    line: 1,
+    column: 1,
+    source: 'analyzer' as const,
+    fingerprint: 'fp',
+  });
+
+  it('never fails an advisory run', () => {
+    expect(exitCodeFor([at('error')], undefined)).toBe(0);
+  });
+
+  it('fails on findings at or above the gate', () => {
+    expect(exitCodeFor([at('error')], 'error')).toBe(1);
+    expect(exitCodeFor([at('error')], 'warning')).toBe(1);
+    expect(exitCodeFor([at('warning')], 'info')).toBe(1);
+  });
+
+  it('passes when every finding is below the gate', () => {
+    expect(exitCodeFor([at('warning'), at('info')], 'error')).toBe(0);
+    expect(exitCodeFor([at('info')], 'warning')).toBe(0);
+  });
+
+  it('passes on an empty scan', () => {
+    expect(exitCodeFor([], 'info')).toBe(0);
+  });
+});
 
 describe('lint-session baseline diff', () => {
   it('detects new/resolved/unchanged deterministically by fingerprint', () => {

--- a/packages/effect-analyzer/src/lint-session.ts
+++ b/packages/effect-analyzer/src/lint-session.ts
@@ -4,7 +4,7 @@ import { createHash } from 'node:crypto';
 import type { LintIssue } from './effect-linter';
 import { lintSourceCode } from './source-linter';
 import { findRuleDoc } from './rule-registry';
-import { runTsgoDiagnostics } from './tsgo-diagnostics';
+import { readTsgoProjectFiles, runTsgoDiagnostics } from './tsgo-diagnostics';
 
 export interface LintFinding {
   readonly filePath: string;
@@ -14,10 +14,46 @@ export interface LintFinding {
   readonly suggestion?: string | undefined;
   readonly line: number;
   readonly column: number;
+  /**
+   * Which checker produced this finding. `tsgo` findings are type-aware Effect
+   * language service diagnostics; `analyzer` findings are our own AST rules.
+   * Consumers gate on this instead of guessing from the rule name.
+   */
+  readonly source: 'analyzer' | 'tsgo';
+  /** The 377xxx Effect language service code. Only present on `tsgo` findings. */
+  readonly code?: number | undefined;
+  readonly endLine?: number | undefined;
+  readonly endColumn?: number | undefined;
   readonly fingerprint: string;
   readonly suppressed?: boolean | undefined;
   readonly suppressionReason?: string | undefined;
 }
+
+/**
+ * Severity gate for the process exit status. `undefined` means advisory-only:
+ * findings are reported but never change the exit code, so a consumer can tell
+ * an advisory run apart from a failed one without re-checking anything.
+ */
+export type FailOnSeverity = LintFinding['severity'];
+
+const SEVERITY_ORDER: Record<LintFinding['severity'], number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+};
+
+/**
+ * Exit code for a scan under a severity gate: 1 when any finding is at or above
+ * `failOn`, 0 otherwise.
+ */
+export const exitCodeFor = (
+  findings: readonly LintFinding[],
+  failOn: FailOnSeverity | undefined,
+): 0 | 1 => {
+  if (failOn === undefined) return 0;
+  const threshold = SEVERITY_ORDER[failOn];
+  return findings.some((f) => SEVERITY_ORDER[f.severity] >= threshold) ? 1 : 0;
+};
 
 export interface Suppression {
   readonly filePath?: string | undefined;
@@ -26,11 +62,24 @@ export interface Suppression {
   readonly reason?: string | undefined;
 }
 
+/**
+ * What the Effect language service actually covered. Without this a run where
+ * tsgo checked nothing — a stale or mistargeted tsconfig — is indistinguishable
+ * from a genuinely clean one.
+ */
+export interface TsgoCoverage {
+  readonly filesChecked: number;
+  readonly totalFiles: number;
+  /** Scanned files the language service never checked, sorted. */
+  readonly unchecked: readonly string[];
+}
+
 export interface LintScanResult {
   readonly findings: readonly LintFinding[];
   readonly staleSuppressions: readonly Suppression[];
   readonly suppressionsMissingReason: readonly Suppression[];
   readonly filesScanned: number;
+  readonly tsgo?: TsgoCoverage | undefined;
 }
 
 export interface BaselineComparison {
@@ -84,7 +133,21 @@ const canonicalSort = (a: LintFinding, b: LintFinding): number => {
   return (a.suggestion ?? '').localeCompare(b.suggestion ?? '');
 };
 
-const stableFingerprint = (finding: Omit<LintFinding, 'fingerprint'>): string => {
+/**
+ * A finding's stable identity across runs and releases.
+ *
+ * The key is frozen: baselines written by earlier releases carry these
+ * fingerprints, and `--fail-on-new` compares against them. Adding a field here
+ * renumbers every existing finding and reports the whole backlog as new, so
+ * `source` is deliberately excluded — the same defect found by either checker
+ * is the same defect.
+ */
+export const fingerprintOf = (
+  finding: Pick<
+    LintFinding,
+    'filePath' | 'line' | 'column' | 'rule' | 'severity' | 'message' | 'suggestion'
+  >,
+): string => {
   const key = [
     finding.filePath,
     String(finding.line),
@@ -96,6 +159,8 @@ const stableFingerprint = (finding: Omit<LintFinding, 'fingerprint'>): string =>
   ].join('|');
   return createHash('sha256').update(key).digest('hex').slice(0, 20);
 };
+
+const stableFingerprint = fingerprintOf;
 
 const parseSuppressions = (source: string): readonly Suppression[] => {
   const lines = source.split(/\r?\n/);
@@ -172,6 +237,7 @@ const toFinding = (filePath: string, issue: LintIssue): LintFinding => {
     suggestion: issue.suggestion,
     line,
     column,
+    source: 'analyzer' as const,
   };
   return {
     ...base,
@@ -236,9 +302,12 @@ export const runSourceLintScan = async (
   // Type-aware rules from the official Effect language service, when available.
   // ponytail: tsgo diagnostics bypass our disable pragmas — tsgo has its own
   // suppression story; wire the two together only if users actually ask.
+  let tsgo: TsgoCoverage | undefined;
   if (options.tsgoProject) {
     const scanned = new Set(candidates);
-    for (const diagnostic of runTsgoDiagnostics({ project: options.tsgoProject })) {
+    const result = runTsgoDiagnostics({ project: options.tsgoProject });
+    const inProject = new Set(readTsgoProjectFiles(options.tsgoProject));
+    for (const diagnostic of result.diagnostics) {
       const filePath = resolve(diagnostic.filePath);
       if (!scanned.has(filePath)) continue;
       const base = {
@@ -249,9 +318,19 @@ export const runSourceLintScan = async (
         suggestion: undefined,
         line: diagnostic.line,
         column: diagnostic.column,
+        source: diagnostic.source,
+        code: diagnostic.code,
+        endLine: diagnostic.endLine,
+        endColumn: diagnostic.endColumn,
       };
       findings.push({ ...base, fingerprint: stableFingerprint(base) });
     }
+    const unchecked = candidates.filter((c) => !inProject.has(c));
+    tsgo = {
+      filesChecked: result.summary.filesChecked,
+      totalFiles: result.summary.totalFiles,
+      unchecked,
+    };
   }
 
   return {
@@ -259,6 +338,7 @@ export const runSourceLintScan = async (
     staleSuppressions,
     suppressionsMissingReason,
     filesScanned: candidates.length,
+    tsgo,
   };
 };
 

--- a/packages/effect-analyzer/src/tsgo-diagnostics.test.ts
+++ b/packages/effect-analyzer/src/tsgo-diagnostics.test.ts
@@ -6,7 +6,6 @@ import { spawnSync } from 'node:child_process';
 import {
   parseTsgoProjectArgument,
   parseTsgoOutput,
-  readTsgoLspConfig,
   resolveTsgoBin,
   resolveTsgoProjectPath,
   runTsgoDiagnostics,
@@ -46,7 +45,7 @@ const SAMPLE = JSON.stringify({
 
 describe('tsgo-diagnostics', () => {
   it('maps diagnostics and downgrades "message" to info', () => {
-    const parsed = parseTsgoOutput(SAMPLE);
+    const parsed = parseTsgoOutput(SAMPLE)?.diagnostics;
     expect(parsed).toEqual([
       {
         filePath: '/repo/src/a.ts',
@@ -55,6 +54,12 @@ describe('tsgo-diagnostics', () => {
         message: 'This Effect is neither yielded nor assigned.',
         line: 3,
         column: 7,
+        endLine: 3,
+        endColumn: 12,
+        start: 10,
+        length: 5,
+        code: 377024,
+        source: 'tsgo',
       },
       {
         filePath: '/repo/src/b.ts',
@@ -63,12 +68,28 @@ describe('tsgo-diagnostics', () => {
         message: 'Use Effect.log.',
         line: 1,
         column: 1,
+        endLine: 1,
+        endColumn: 2,
+        start: 1,
+        length: 1,
+        code: 377065,
+        source: 'tsgo',
       },
     ]);
   });
 
+  it('carries the summary so a zero-file run is distinguishable from a clean one', () => {
+    expect(parseTsgoOutput(SAMPLE)?.summary).toEqual({
+      filesChecked: 2,
+      totalFiles: 2,
+      errors: 1,
+      warnings: 0,
+      messages: 1,
+    });
+  });
+
   it('tolerates leading noise on stdout', () => {
-    expect(parseTsgoOutput(`Checking project...\n${SAMPLE}`)).toHaveLength(2);
+    expect(parseTsgoOutput(`Checking project...\n${SAMPLE}`)?.diagnostics).toHaveLength(2);
   });
 
   it('returns undefined instead of throwing on unusable output', () => {
@@ -76,94 +97,6 @@ describe('tsgo-diagnostics', () => {
     expect(parseTsgoOutput('no json here')).toBeUndefined();
     expect(parseTsgoOutput('{ broken')).toBeUndefined();
     expect(parseTsgoOutput('{"summary":{}}')).toBeUndefined();
-  });
-
-  describe('readTsgoLspConfig', () => {
-    const withTsconfig = (contents: string, fn: (path: string) => void) => {
-      const root = mkdtempSync(join(tmpdir(), 'effect-analyze-lspconfig-'));
-      try {
-        const p = join(root, 'tsconfig.json');
-        writeFileSync(p, contents, 'utf8');
-        fn(p);
-      } finally {
-        rmSync(root, { recursive: true, force: true });
-      }
-    };
-
-    it('forwards the plugin options, dropping the name', () => {
-      withTsconfig(
-        JSON.stringify({
-          compilerOptions: {
-            plugins: [
-              { name: 'other-plugin', diagnosticSeverity: { ignored: 'error' } },
-              { name: '@effect/tsgo', diagnosticSeverity: { floatingEffect: 'error' } },
-            ],
-          },
-        }),
-        (p) => {
-          expect(JSON.parse(readTsgoLspConfig(p))).toEqual({
-            diagnosticSeverity: { floatingEffect: 'error' },
-          });
-        },
-      );
-    });
-
-    it('falls back to rule defaults when there is no plugin entry', () => {
-      withTsconfig(JSON.stringify({ compilerOptions: {} }), (p) => {
-        expect(readTsgoLspConfig(p)).toBe('{}');
-      });
-    });
-
-    it('parses comments and trailing commas accepted by tsconfig', () => {
-      withTsconfig(
-        `{
-          // Keep CLI diagnostics aligned with the editor.
-          "compilerOptions": {
-            "plugins": [{
-              "name": "@effect/tsgo",
-              "diagnosticSeverity": { "globalConsoleInEffect": "warning" },
-            }],
-          },
-        }`,
-        (p) => {
-          expect(JSON.parse(readTsgoLspConfig(p))).toEqual({
-            diagnosticSeverity: { globalConsoleInEffect: 'warning' },
-          });
-        },
-      );
-    });
-
-    it('follows inherited plugin options', () => {
-      const root = mkdtempSync(join(tmpdir(), 'effect-analyze-lspconfig-extends-'));
-      try {
-        writeFileSync(
-          join(root, 'base.json'),
-          JSON.stringify({
-            compilerOptions: {
-              plugins: [
-                {
-                  name: '@effect/tsgo',
-                  diagnosticSeverity: { globalErrorInEffectFailure: 'error' },
-                },
-              ],
-            },
-          }),
-          'utf8',
-        );
-        const project = join(root, 'tsconfig.json');
-        writeFileSync(project, '{ "extends": "./base.json" }', 'utf8');
-
-        expect(JSON.parse(readTsgoLspConfig(project))).toEqual({
-          diagnosticSeverity: { globalErrorInEffectFailure: 'error' },
-        });
-      } finally {
-        rmSync(root, { recursive: true, force: true });
-      }
-    });
-
-    it('falls back to rule defaults on an unreadable tsconfig', () => {
-      expect(readTsgoLspConfig('/nonexistent/tsconfig.json')).toBe('{}');
-    });
   });
 
   describe('CLI argument handling', () => {
@@ -202,8 +135,13 @@ describe('tsgo-diagnostics', () => {
 
   it('runs the real binary and returns parsed diagnostics', () => {
     const result = runTsgoDiagnostics({ project: 'tsconfig.json' });
-    expect(Array.isArray(result)).toBe(true);
-    for (const d of result ?? []) {
+    expect(Array.isArray(result.diagnostics)).toBe(true);
+    // The run summary travels with the diagnostics, so a caller can tell
+    // "checked and clean" from "checked nothing". This package's own tsconfig
+    // does not enable the `@effect/language-service` plugin, so the language
+    // service correctly checks none of its files.
+    expect(result.summary.totalFiles).toBeGreaterThan(0);
+    for (const d of result.diagnostics) {
       expect(d.filePath).toMatch(/\.tsx?$/);
       expect(['error', 'warning', 'info']).toContain(d.severity);
       expect(d.line).toBeGreaterThan(0);
@@ -237,7 +175,7 @@ export const program = Effect.gen(function* () {
             strict: true,
             skipLibCheck: true,
             noEmit: true,
-            plugins: [{ name: '@effect/tsgo' }],
+            plugins: [{ name: '@effect/language-service' }],
           },
           include: ['src/**/*.ts'],
         }),
@@ -257,7 +195,7 @@ export const program = Effect.gen(function* () {
         helper,
         `import { runTsgoDiagnostics } from ${JSON.stringify(join(__dirname, 'tsgo-diagnostics.ts'))};\n` +
           `const result = runTsgoDiagnostics({ project: ${JSON.stringify(project)} });\n` +
-          `process.stdout.write(JSON.stringify(result ?? []));\n`,
+          `process.stdout.write(JSON.stringify(result.diagnostics));\n`,
         'utf8',
       );
 

--- a/packages/effect-analyzer/src/tsgo-diagnostics.ts
+++ b/packages/effect-analyzer/src/tsgo-diagnostics.ts
@@ -12,7 +12,7 @@
  * aligned with the compiler and language service used by the project.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { nodeModuleLocation } from './register-node-ts-morph';
@@ -25,6 +25,40 @@ export interface TsgoDiagnostic {
   readonly message: string;
   readonly line: number;
   readonly column: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+  /** Byte offset and width of the span, as `@effect/tsgo` reports them. */
+  readonly start: number;
+  readonly length: number;
+  /**
+   * The synthesized TypeScript error code. Every Effect language service
+   * diagnostic lives in the 377xxx range, which is what lets a consumer prove a
+   * finding came from the Effect LSP rather than from the type checker.
+   */
+  readonly code: number;
+  readonly source: 'tsgo';
+}
+
+/** `@effect/tsgo`'s own run summary. `filesChecked: 0` means nothing was checked. */
+export interface TsgoSummary {
+  readonly filesChecked: number;
+  readonly totalFiles: number;
+  readonly errors: number;
+  readonly warnings: number;
+  readonly messages: number;
+}
+
+/** Per-file Effect versions, present only for a `--list-files` run. */
+export interface TsgoFileVersion {
+  readonly file: string;
+  readonly detectedEffect: string;
+  readonly supportedEffect: string;
+}
+
+export interface TsgoResult {
+  readonly diagnostics: readonly TsgoDiagnostic[];
+  readonly summary: TsgoSummary;
+  readonly files: readonly TsgoFileVersion[];
 }
 
 export class TsgoDiagnosticsError extends Error {
@@ -39,9 +73,14 @@ export class TsgoDiagnosticsError extends Error {
 
 interface TsgoJsonDiagnostic {
   readonly file: string;
+  readonly start: number;
+  readonly length: number;
   readonly line: number;
   readonly column: number;
+  readonly endLine: number;
+  readonly endColumn: number;
   readonly severity: 'error' | 'warning' | 'message';
+  readonly code: number;
   readonly name: string;
   readonly message: string;
 }
@@ -87,32 +126,18 @@ const toSeverity = (severity: TsgoJsonDiagnostic['severity']): TsgoDiagnostic['s
   severity === 'message' ? 'info' : severity;
 
 /**
- * Extract the `@effect/tsgo` plugin options from a tsconfig, as inline JSON for
- * `--lspconfig`.
+ * Absolute paths a tsconfig actually includes.
  *
- * `effect-tsgo diagnostics` does NOT read plugin options out of tsconfig — with
- * only a `plugins` entry it reports `filesChecked: 0` and no diagnostics at all.
- * Forwarding the options ourselves is what makes the CLI agree with the editor.
- * ts-morph's config loader is used because tsconfig is JSONC and plugin options
- * may be inherited through `extends`. `{}` means "enable with rule defaults"
- * and is used only when no plugin entry can be loaded.
+ * A file we scanned that is absent from this list was never in the language
+ * service's scope, so its lack of diagnostics is not evidence that it is clean.
  */
-export const readTsgoLspConfig = (projectPath: string): string => {
+export const readTsgoProjectFiles = (projectPath: string): readonly string[] => {
   try {
     const { Project } = loadTsMorph();
-    const project = new Project({
-      tsConfigFilePath: projectPath,
-      skipAddingFilesFromTsConfig: true,
-    });
-    const plugins = project.getCompilerOptions().plugins as
-      | readonly Record<string, unknown>[]
-      | undefined;
-    const plugin = plugins?.find((p) => p['name'] === '@effect/tsgo');
-    if (!plugin) return '{}';
-    const { name: _name, ...options } = plugin;
-    return JSON.stringify(options);
+    const project = new Project({ tsConfigFilePath: projectPath });
+    return project.getSourceFiles().map((f) => resolve(f.getFilePath()));
   } catch {
-    return '{}';
+    return [];
   }
 };
 
@@ -146,26 +171,48 @@ export const resolveTsgoProjectPath = (project: string, cwd: string): string =>
  * Parse the `--format json` payload. Tolerates leading noise on stdout and
  * returns `undefined` rather than throwing on anything unexpected.
  */
-export const parseTsgoOutput = (stdout: string): readonly TsgoDiagnostic[] | undefined => {
+export const parseTsgoOutput = (stdout: string): TsgoResult | undefined => {
   const start = stdout.indexOf('{');
   if (start === -1) return undefined;
-  let parsed: { diagnostics?: readonly TsgoJsonDiagnostic[] };
+  type TsgoJsonOutput = {
+    diagnostics?: readonly TsgoJsonDiagnostic[];
+    summary?: Partial<TsgoSummary>;
+    files?: readonly TsgoFileVersion[];
+  };
+  let parsed: TsgoJsonOutput;
   try {
-    parsed = JSON.parse(stdout.slice(start)) as { diagnostics?: readonly TsgoJsonDiagnostic[] };
+    parsed = JSON.parse(stdout.slice(start)) as TsgoJsonOutput;
   } catch {
     return undefined;
   }
   const diagnostics = parsed.diagnostics;
   if (!Array.isArray(diagnostics)) return undefined;
 
-  return diagnostics.map((d: TsgoJsonDiagnostic) => ({
-    filePath: d.file,
-    rule: d.name,
-    severity: toSeverity(d.severity),
-    message: d.message,
-    line: d.line,
-    column: d.column,
-  }));
+  const summary = parsed.summary ?? {};
+  return {
+    diagnostics: diagnostics.map((d: TsgoJsonDiagnostic) => ({
+      filePath: d.file,
+      rule: d.name,
+      severity: toSeverity(d.severity),
+      message: d.message,
+      line: d.line,
+      column: d.column,
+      endLine: d.endLine,
+      endColumn: d.endColumn,
+      start: d.start,
+      length: d.length,
+      code: d.code,
+      source: 'tsgo' as const,
+    })),
+    summary: {
+      filesChecked: summary.filesChecked ?? 0,
+      totalFiles: summary.totalFiles ?? 0,
+      errors: summary.errors ?? 0,
+      warnings: summary.warnings ?? 0,
+      messages: summary.messages ?? 0,
+    },
+    files: parsed.files ?? [],
+  };
 };
 
 /**
@@ -176,11 +223,61 @@ export const parseTsgoOutput = (stdout: string): readonly TsgoDiagnostic[] | und
  * error because callers only invoke this function after explicitly requesting
  * official type-aware diagnostics.
  */
-export const runTsgoDiagnostics = (options: {
-  readonly project: string;
+export interface TsgoProcessResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number;
+}
+
+/**
+ * Run `effect-tsgo diagnostics` with the caller's own argv and return its raw
+ * output.
+ *
+ * Nothing here interprets or re-renders what comes back: `@effect/tsgo`
+ * validates its own flags, formats its own diagnostics and chooses its own exit
+ * code, which is the only way a wrapper stays identical to it across releases.
+ */
+export const spawnTsgoDiagnostics = (
+  argv: readonly string[],
+  options: { readonly cwd?: string; readonly timeoutMs?: number; readonly inheritStderr?: boolean } = {},
+): TsgoProcessResult => {
+  const bin = resolveTsgoBin();
+  if (!bin) {
+    throw new TsgoDiagnosticsError(
+      'Unable to resolve @effect/tsgo. Reinstall effect-analyzer and its platform dependencies.',
+    );
+  }
+  const result = spawnSync(process.execPath, [bin, 'diagnostics', ...argv], {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: options.timeoutMs ?? 120_000,
+    stdio: ['ignore', 'pipe', options.inheritStderr === true ? 'inherit' : 'pipe'],
+  });
+  if (result.error) throw result.error;
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status ?? 1,
+  };
+};
+
+export interface RunTsgoOptions {
+  /** Project to check. Optional when `file` is given, as upstream allows. */
+  readonly project?: string | undefined;
+  /** Single file to check, forwarded as `--file`. */
+  readonly file?: string | undefined;
   readonly cwd?: string;
   readonly timeoutMs?: number;
-}): readonly TsgoDiagnostic[] => {
+  /** Inline JSON replacing the project's plugin options, as `--lspconfig`. */
+  readonly lspconfig?: string | undefined;
+  readonly severity?: string | undefined;
+  readonly strict?: boolean;
+  readonly progress?: boolean;
+  readonly listFiles?: boolean;
+}
+
+export const runTsgoDiagnostics = (options: RunTsgoOptions): TsgoResult => {
   const bin = resolveTsgoBin();
   if (!bin) {
     throw new TsgoDiagnosticsError(
@@ -189,26 +286,38 @@ export const runTsgoDiagnostics = (options: {
   }
 
   const projectResolutionCwd = options.cwd ?? process.cwd();
-  const projectPath = resolveTsgoProjectPath(options.project, projectResolutionCwd);
+  const projectPath = options.project === undefined
+    ? undefined
+    : resolveTsgoProjectPath(options.project, projectResolutionCwd);
   // When the caller supplies an absolute project from another cwd, execute in
   // the project directory so effect-tsgo resolves that consumer's TypeScript
   // and Effect packages rather than packages belonging to the host process.
-  const cwd = options.cwd ?? dirname(projectPath);
+  const cwd = options.cwd ?? (projectPath === undefined ? process.cwd() : dirname(projectPath));
+
+  // Only what the caller asked for: `@effect/tsgo` reads the project's own
+  // `@effect/language-service` plugin options, and synthesising one here would
+  // replace configured severities with rule defaults.
+  const lspconfig = options.lspconfig;
+
+  const argv = [
+    bin,
+    'diagnostics',
+    ...(projectPath === undefined ? [] : ['--project', projectPath]),
+    ...(options.file === undefined ? [] : ['--file', options.file]),
+    '--format',
+    'json',
+    ...(options.severity === undefined ? [] : ['--severity', options.severity]),
+    ...(options.strict === true ? ['--strict'] : []),
+    ...(options.progress === true ? ['--progress'] : []),
+    ...(options.listFiles === true ? ['--list-files'] : []),
+    ...(lspconfig === undefined ? [] : ['--lspconfig', lspconfig]),
+  ];
 
   let stdout: string;
   try {
     stdout = execFileSync(
       process.execPath,
-      [
-        bin,
-        'diagnostics',
-        '--project',
-        projectPath,
-        '--format',
-        'json',
-        '--lspconfig',
-        readTsgoLspConfig(projectPath),
-      ],
+      argv,
       {
         cwd,
         encoding: 'utf-8',
@@ -216,7 +325,9 @@ export const runTsgoDiagnostics = (options: {
         // on stdout, so read it from the thrown error rather than bailing out.
         maxBuffer: 64 * 1024 * 1024,
         timeout: options.timeoutMs ?? 120_000,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        // `--progress` narrates to stderr; let it through so it reaches the
+        // user's terminal instead of being buffered and discarded.
+        stdio: ['ignore', 'pipe', options.progress === true ? 'inherit' : 'pipe'],
       },
     );
   } catch (error) {
@@ -230,8 +341,8 @@ export const runTsgoDiagnostics = (options: {
       : typeof out === 'string'
         ? out
         : out.toString('utf-8');
-    const diagnostics = parseTsgoOutput(stdout);
-    if (diagnostics) return diagnostics;
+    const result = parseTsgoOutput(stdout);
+    if (result) return result;
 
     const stderr = processError.stderr;
     const detail = stderr === undefined
@@ -239,19 +350,20 @@ export const runTsgoDiagnostics = (options: {
       : typeof stderr === 'string'
         ? stderr.trim()
         : stderr.toString('utf-8').trim();
+    const target = projectPath ?? options.file ?? '(no target)';
     throw new TsgoDiagnosticsError(
       detail.length > 0
         ? `@effect/tsgo diagnostics failed: ${detail}`
-        : `@effect/tsgo diagnostics failed for ${projectPath}`,
+        : `@effect/tsgo diagnostics failed for ${target}`,
       error,
     );
   }
 
-  const diagnostics = parseTsgoOutput(stdout);
-  if (!diagnostics) {
+  const result = parseTsgoOutput(stdout);
+  if (!result) {
     throw new TsgoDiagnosticsError(
-      `@effect/tsgo returned unparseable diagnostics for ${projectPath}`,
+      `@effect/tsgo returned unparseable diagnostics for ${projectPath ?? options.file ?? '(no target)'}`,
     );
   }
-  return diagnostics;
+  return result;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
   packages/effect-analyzer:
     dependencies:
       '@effect/tsgo':
-        specifier: 0.37.0
-        version: 0.37.0
+        specifier: 0.39.0
+        version: 0.39.0
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0
@@ -542,43 +542,43 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@effect/tsgo-darwin-arm64@0.37.0':
-    resolution: {integrity: sha512-D9o2NKswmRklu+sG28HkxZAvtvOa0Mt+bLVjJKydF2kVw+gePxiHuTbbI3e4Kqumv4ucLT3TtqU1a2RirC80lA==}
+  '@effect/tsgo-darwin-arm64@0.39.0':
+    resolution: {integrity: sha512-ahkZmztsGVZm1mUeAr5ABQn1GzVd1p40gpt5SbDdaSbG0ApDQHEPNtPYvuhN7dVpNtpgQX/AVdkxE92o/wHeIg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@effect/tsgo-darwin-x64@0.37.0':
-    resolution: {integrity: sha512-3PP9ktZOOYaPhGSP01ySM44pJbeLJZUuF2auCRTIxySHqe2vvhxVAIGGCwmMzOg0qeqowOUG8ew4kofmqRsXCg==}
+  '@effect/tsgo-darwin-x64@0.39.0':
+    resolution: {integrity: sha512-dD8V3U7166mvnvdOKgIqXDYKj4r2hYFJiL6ATKmeQeaZkqNg/56trUeWri4xdA6u38gDJ0zE3y4h+Aqm8XWYOw==}
     cpu: [x64]
     os: [darwin]
 
-  '@effect/tsgo-linux-arm64@0.37.0':
-    resolution: {integrity: sha512-7rICv3nNPSo5gPPUOSBJyYU1Hu8yRX2IqRWATXhhuPUJ3yQwLevAim6AyzZp/FMoKUYgr+SZ18dw6BntAdzMrA==}
+  '@effect/tsgo-linux-arm64@0.39.0':
+    resolution: {integrity: sha512-LE7hh8kjWMDBc8W4pznT43msmqx/uVx7tGrjrnF++ofVkfEYjIFDi6aEZGAILomlXd/1ktCM+wa4aQTPCMK8BQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@effect/tsgo-linux-arm@0.37.0':
-    resolution: {integrity: sha512-JEtNv5gI6gHjtrYMz5ln6uZIMKwUGgxsDHpJgBPUd+yS/Cm48b4SjpLuYRBEvjPJTxPM6asEkyKsBMlboJfoIg==}
+  '@effect/tsgo-linux-arm@0.39.0':
+    resolution: {integrity: sha512-10SBO6Rc2VSyRxgUYhQRhm4cXRJK3UAGzhgcg0PoycP8un2rzMTHC4+PkwlAFtJijhslI786Ei+WrvvPjiSybw==}
     cpu: [arm]
     os: [linux]
 
-  '@effect/tsgo-linux-x64@0.37.0':
-    resolution: {integrity: sha512-gPl5KO83aU55JXEv2lBjOLRdZafP+/fAl2mveZArU+QsOf5MuUnFmSRo+eds0/971wH3a13lW9sWBg+/XZtq8g==}
+  '@effect/tsgo-linux-x64@0.39.0':
+    resolution: {integrity: sha512-AhOHFZyZrOLYZYEjFgpdRvURMw+x/CIdSBTWMLiU8yR7gRj0+R2cj1jzAp5hwnDw4eM0zU3w0ZzzOgJ6OUndwQ==}
     cpu: [x64]
     os: [linux]
 
-  '@effect/tsgo-win32-arm64@0.37.0':
-    resolution: {integrity: sha512-ipmWCTitf6CYn4sAqOxwvv48JlE46SfvDq1I912OPnPHBP3ZnYF1b18RqiOCiL4Z1aQ6pC5NTeyulfW8g9cM7Q==}
+  '@effect/tsgo-win32-arm64@0.39.0':
+    resolution: {integrity: sha512-iRhJs8+sWrzBEdlwVOZnAtt5eJXNPzz8HNeiZ4K4DhC88qDz46pZOcO96NKhXWkKC2WswsSOO2bRTZVTI3xHdQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@effect/tsgo-win32-x64@0.37.0':
-    resolution: {integrity: sha512-h2UGN9UN+wyQ3KxyShOFyCy0CcgxvC9AoKv1OpZACWqw0ewU4ga6kyN5cmOY94JWXolcTgwhd/DUqN3IaEyoPw==}
+  '@effect/tsgo-win32-x64@0.39.0':
+    resolution: {integrity: sha512-enRgSWn1a0l9lLjVqLHVbIz1MuBhKpaeoCLqqCO9HtSt3xAhEWSGtN6ESwXPRUIiKakqTOKvWdk68zIrJ+Ho0A==}
     cpu: [x64]
     os: [win32]
 
-  '@effect/tsgo@0.37.0':
-    resolution: {integrity: sha512-jCJIUcNgI0vaoylao/mhOv+7hDfaJRwZJSJrg5kA/FCQ4aGDhAYqyQx+hoZh8AW3pzD9Qp1RWtUsVFqOzIOENw==}
+  '@effect/tsgo@0.39.0':
+    resolution: {integrity: sha512-vP4gdaVnAQy6NaMDKFaPeaPU63HaoVsdbP7axEcHxwJJMwE2llocXEplIwsYM6EvBVMtwtiBCvl9K2aFVNlZPA==}
     hasBin: true
 
   '@emnapi/core@1.11.1':
@@ -5118,36 +5118,36 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@effect/tsgo-darwin-arm64@0.37.0':
+  '@effect/tsgo-darwin-arm64@0.39.0':
     optional: true
 
-  '@effect/tsgo-darwin-x64@0.37.0':
+  '@effect/tsgo-darwin-x64@0.39.0':
     optional: true
 
-  '@effect/tsgo-linux-arm64@0.37.0':
+  '@effect/tsgo-linux-arm64@0.39.0':
     optional: true
 
-  '@effect/tsgo-linux-arm@0.37.0':
+  '@effect/tsgo-linux-arm@0.39.0':
     optional: true
 
-  '@effect/tsgo-linux-x64@0.37.0':
+  '@effect/tsgo-linux-x64@0.39.0':
     optional: true
 
-  '@effect/tsgo-win32-arm64@0.37.0':
+  '@effect/tsgo-win32-arm64@0.39.0':
     optional: true
 
-  '@effect/tsgo-win32-x64@0.37.0':
+  '@effect/tsgo-win32-x64@0.39.0':
     optional: true
 
-  '@effect/tsgo@0.37.0':
+  '@effect/tsgo@0.39.0':
     optionalDependencies:
-      '@effect/tsgo-darwin-arm64': 0.37.0
-      '@effect/tsgo-darwin-x64': 0.37.0
-      '@effect/tsgo-linux-arm': 0.37.0
-      '@effect/tsgo-linux-arm64': 0.37.0
-      '@effect/tsgo-linux-x64': 0.37.0
-      '@effect/tsgo-win32-arm64': 0.37.0
-      '@effect/tsgo-win32-x64': 0.37.0
+      '@effect/tsgo-darwin-arm64': 0.39.0
+      '@effect/tsgo-darwin-x64': 0.39.0
+      '@effect/tsgo-linux-arm': 0.39.0
+      '@effect/tsgo-linux-arm64': 0.39.0
+      '@effect/tsgo-linux-x64': 0.39.0
+      '@effect/tsgo-win32-arm64': 0.39.0
+      '@effect/tsgo-win32-x64': 0.39.0
 
   '@emnapi/core@1.11.1':
     dependencies:


### PR DESCRIPTION
## Summary

`effect-analyze` becomes a drop-in replacement for the `effect-tsgo` CLI, so a project can swap the binary without changing scripts or CI — and gets the analyzer's own rules in the same report.

## `diagnostics`

```bash
effect-analyze diagnostics --project tsconfig.json --format json
effect-analyze setup | config | patch | unpatch | get-exe-path
```

Flags are forwarded to `@effect/tsgo` untouched, so it validates its own flags, reads the project's `@effect/language-service` plugin configuration and picks its own exit code. Its output is passed through: `text`, `pretty` and `github-actions` are byte-identical to the native binary, diagnostic order and summary trailer included. The other subcommands are forwarded verbatim, so one CLI covers configuration and diagnostics.

The design rule is that we never reimplement what `@effect/tsgo` already does. Parity is enforced by tests that run both binaries and compare their output.

## What it adds

Every JSON entry carries a `source` (`tsgo` or `analyzer`) alongside upstream's schema, so a consumer can tell a type-aware Effect diagnostic from one of ours — and both from a TypeScript compiler error. Analyzer rules carry `code: 0`, outside the `377xxx` Effect range, so filtering on that range behaves exactly as before. `--no-analyzer` reports only the language service.

## `--lint-source`

- `--fail-on=error|warning|info` gates the exit status on severity; without it a run stays advisory and never changes the exit code.
- Findings carry `source` and, for language service diagnostics, the `377xxx` `code` and end position.
- The summary reports what the language service covered (`summary.tsgo.filesChecked` and `unchecked`), so a partially checked run is distinguishable from a clean one.

Also fixes truncated output: piping a report larger than the pipe buffer cut it mid-string, because the CLI exited before stdout had drained.

## Notes

- Requires `@effect/tsgo` 0.39.0.
- Docs updated: CLI reference, source-linter, agent-guardrails, README, and the `effect-analyzer` skill.

## Test plan

- `pnpm quality` green: 1573 tests, lint, type-check, docs build.
- Parity tests run `effect-analyze` and `effect-tsgo` against the same configured project and compare JSON, `text`, `pretty` and `github-actions` output, exit codes and `--severity` semantics.
