### PR TITLE
feat: CLI developer experience — runtime overlay, globs, clean output streams

### DIFF
--- a/.changeset/cli-dx.md
+++ b/.changeset/cli-dx.md
@@ -1,0 +1,10 @@
+---
+'effect-analyzer': minor
+---
+
+Sharpen the CLI's output and directory walk. Progress, counts and warnings now
+go to stderr, so `--format mermaid > diagram.mmd` writes a file that parses
+while the status stays visible in the terminal. A run over several paths with
+`--format json` prints one array, so `| jq` reads the whole run. `--extensions`
+and `--max-depth` expose the directory walk's discovery rules, which until now
+were fixed at `.ts`/`.tsx` and ten levels.

--- a/.changeset/multi-path-and-globs.md
+++ b/.changeset/multi-path-and-globs.md
@@ -1,0 +1,10 @@
+---
+'effect-analyzer': minor
+---
+
+Accept several paths and globs on the command line. `effect-analyze src/a.ts
+src/b.ts` analyzes each file in turn, so an unquoted shell glob works, and a
+quoted glob such as `'src/**/*.ts'` is expanded by the CLI itself through
+`fs.glob`. A pattern that matches nothing is reported, and modes that read one
+directory, follow one file, or write one output file say so rather than picking
+whichever path came first.

--- a/.changeset/runtime-trace-overlay.md
+++ b/.changeset/runtime-trace-overlay.md
@@ -1,0 +1,9 @@
+---
+'effect-analyzer': minor
+---
+
+Overlay a captured runtime trace on a diagram: `--runtime-trace <file>` colors a
+`--format mermaid` diagram by span status and reports how each span matched.
+`traceFromSpanTree()` decodes traces exported as a nested span tree, and span
+matching resolves the longest unique path suffix, so spans opened above the
+analyzed program still light up everything that ran beneath them.

--- a/.changeset/starlight-icon-import.md
+++ b/.changeset/starlight-icon-import.md
@@ -1,0 +1,7 @@
+---
+'effect-analyzer': patch
+---
+
+Import Starlight's `Icon` from `@astrojs/starlight/components` in the docs app's
+theme provider. The previous relative path into `node_modules` pointed at a file
+Starlight 0.42 no longer ships there, which broke the documentation build.

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -64,6 +64,10 @@ A path argument is a file, a directory (walked for `.ts`/`.tsx`, skipping `node_
 
 Multi-path runs go through `runManyPaths` (`cli.ts`), which refuses modes that read one directory (`--coverage-audit`, `--service-cycles`), follow one file (`--watch`, `--entry-points`, `--config-leaks`, `--cli-commands`), write one file (`--output`), or render from one entry point (`SINGLE_PATH_FORMATS`). Modes dispatched before path resolution (`--lint-source`, the report flags, the rules flags) reject extra positionals outright; `--diff` reads the positionals itself.
 
+### Output Streams
+
+The rendered result goes to stdout; progress and counts go to stderr through `logProgress` (`cli-mode-analysis.ts`), so `--format mermaid > file.mmd` yields a file that parses. `--quiet` silences the status lines. In a multi-path run `--format json` is collected and printed as one array — `runAnalysis` takes an optional `emit` sink for exactly that.
+
 ### Output Formats
 
 `effect-analyze <path> --format <fmt>`:
@@ -236,6 +240,8 @@ it. Adding a field to that key renumbers every existing finding.
 | `-c, --compact` | Compact output |
 | `--pretty` | Pretty-print (default) |
 | `--tsconfig <path>` | Custom tsconfig.json path |
+| `--extensions <list>` | Extensions to discover in a directory walk (default: `ts,tsx`) |
+| `--max-depth <n>` | Directory walk depth (default: 10) |
 | `--tsgo[=<tsconfig>]` | Merge official `@effect/tsgo` diagnostics (TypeScript 7+) |
 | `--fail-on <severity>` | Exit 1 on a finding at or above `error`/`warning`/`info` (for `--lint-source`; omit for an advisory run) |
 | `--no-metadata` | Exclude metadata |

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -111,6 +111,12 @@ effect-analyze --diff v1.ts v2.ts --include-trivial  # Include trivial changes
 
 Renderers: `renderDiffMarkdown()`, `renderDiffJSON()`, `renderDiffMermaid()`
 
+### Runtime Overlay
+
+`--runtime-trace <file>` colors a `--format mermaid` diagram with a captured trace. The file is a nested span tree (`spanId`, `name`, `status: ok | error | unset`, optional `durationMs` and `running`, `children`), decoded by `traceFromSpanTree()`; `traceFromEffectSpans()` and `traceFromOpenTelemetry()` cover the other two shapes.
+
+Spans join to IR nodes by nested span path, falling back to the longest path suffix that identifies a single node, so spans opened above the analyzed program still resolve what runs beneath them. The diagram ends with `%% runtime overlay: N matched, N matched by suffix, N unmatched, N ambiguous`; `RuntimeOverlayResult` carries the same four lists.
+
 ### Interactive HTML
 
 ```bash
@@ -220,6 +226,7 @@ it. Adding a field to that key renumbers every existing finding.
 | `--export <name>` | For `openapi-runtime`: HttpApi export name |
 | `-o, --output <file>` | Output file (default: stdout) |
 | `-d, --direction <dir>` | Mermaid direction: TB, LR, BT, RL |
+| `--runtime-trace <file>` | Overlay a span-tree JSON trace on `--format mermaid` |
 | `-c, --compact` | Compact output |
 | `--pretty` | Pretty-print (default) |
 | `--tsconfig <path>` | Custom tsconfig.json path |
@@ -297,6 +304,7 @@ Exported from the focused package entry points, primarily `effect-analyzer/analy
 ```typescript
 import {
   renderStaticMermaid, renderEnhancedMermaid, renderRailwayMermaid,
+  renderMermaidWithRuntimeTrace, traceFromSpanTree, traceFromEffectSpans, traceFromOpenTelemetry,
   renderInteractiveHTML,
   renderDiffMarkdown, renderDiffJSON, renderDiffMermaid,
   generateTestMatrix, formatTestMatrixMarkdown, formatTestMatrixAsCode, formatTestChecklist,

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -58,6 +58,12 @@ effect-analyze [PATH] [options]
 
 PATH defaults to `.` (current directory). When PATH is a directory, analyzes all TypeScript files and writes colocated `.effect-analysis.md` next to each file containing Effect programs.
 
+### Paths
+
+A path argument is a file, a directory (walked for `.ts`/`.tsx`, skipping `node_modules` and `.git`, depth 10), or a glob. Several paths analyze in turn, so an unquoted shell glob works; a quoted glob is expanded by the CLI itself through `expandCliPaths` (`cli-support.ts`, backed by `fs.glob`). A pattern matching nothing fails with `No files matched: <pattern>`.
+
+Multi-path runs go through `runManyPaths` (`cli.ts`), which refuses modes that read one directory (`--coverage-audit`, `--service-cycles`), follow one file (`--watch`, `--entry-points`, `--config-leaks`, `--cli-commands`), write one file (`--output`), or render from one entry point (`SINGLE_PATH_FORMATS`). Modes dispatched before path resolution (`--lint-source`, the report flags, the rules flags) reject extra positionals outright; `--diff` reads the positionals itself.
+
 ### Output Formats
 
 `effect-analyze <path> --format <fmt>`:

--- a/apps/docs/src/components/ThemeProvider.astro
+++ b/apps/docs/src/components/ThemeProvider.astro
@@ -3,7 +3,7 @@
  * Fork of Starlight’s ThemeProvider: first visit defaults to dark (not system preference).
  * `localStorage` key `starlight-theme`: missing = dark; '' = auto; `light` | `dark` = explicit.
  */
-import Icon from '../../node_modules/@astrojs/starlight/user-components/Icon.astro';
+import { Icon } from '@astrojs/starlight/components';
 ---
 
 {/* This is intentionally inlined to avoid FOUC. */}

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -169,7 +169,7 @@ const report = computeDiagramFidelity(ir)
 console.log(formatDiagramFidelity(report))
 ```
 
-Use `traceFromEffectSpans()` for Effect v4 spans or `traceFromOpenTelemetry()` for exported OpenTelemetry spans. `renderMermaidWithRuntimeTrace()` colors matched nodes by runtime status and returns unmatched or ambiguous span IDs.
+Use `traceFromEffectSpans()` for Effect v4 spans, `traceFromOpenTelemetry()` for exported OpenTelemetry spans, or `traceFromSpanTree()` for tools that export a trace as a nested span tree. `renderMermaidWithRuntimeTrace()` colors matched nodes by runtime status and reports how each span matched.
 
 ```ts
 import {

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -50,6 +50,7 @@ Every error is reported, then the CLI exits 1 without running. A missing value (
 | `--style-guide` | Apply style-guide heuristics for cleaner, more readable diagrams | off |
 | `--no-style-guide` | Explicitly disable style-guide mode | — |
 | `--assert-diagram-fidelity` | Exit with code 1 when a diagram contains unresolved or ambiguous nodes | off |
+| `--runtime-trace <file>` | Overlay a captured trace on `--format mermaid` (see [Diagram Fidelity](/effect-analyzer/reference/diagram-fidelity/)) | off |
 
 ## Analysis Modes
 

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -12,10 +12,33 @@ The `effect-analyze` CLI analyzes Effect TypeScript files and produces diagrams,
 ## Usage
 
 ```bash
-effect-analyze [path] [options]
+effect-analyze [path...] [options]
 ```
 
-When `path` is a file, the analyzer processes that file. When it is a directory, it processes all TypeScript files within it. Multiple paths can be provided for diff mode.
+A path is a file, a directory, or a glob.
+
+| Argument | Behavior |
+|---|---|
+| `src/transfer.ts` | Analyzes that file |
+| `src` | Walks the directory for `.ts` and `.tsx` files, skipping `node_modules` and `.git` |
+| `src/transfer.ts src/refund.ts` | Analyzes each file in turn, so an unquoted shell glob works |
+| `'src/**/*.ts'` | Quoted, so the CLI expands the pattern itself |
+
+A pattern that matches nothing is an error, not an empty run:
+
+```bash
+$ effect-analyze 'src/**/*.missing'
+Error: No files matched: src/**/*.missing
+```
+
+Modes that read one directory (`--coverage-audit`, `--service-cycles`), follow one file (`--watch`, `--entry-points`), or write one file (`--output`) say so rather than picking whichever path came first:
+
+```bash
+$ effect-analyze src/transfer.ts src/refund.ts -o diagram.mmd
+Error: 2 paths given. --output writes one file. Drop it, or pass one path.
+```
+
+Diff mode reads its two sources from the positional arguments, so `--diff` keeps its own `<git-ref>:<path>` syntax.
 
 ## General Options
 

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -40,6 +40,16 @@ Error: 2 paths given. --output writes one file. Drop it, or pass one path.
 
 Diff mode reads its two sources from the positional arguments, so `--diff` keeps its own `<git-ref>:<path>` syntax.
 
+## Output Streams
+
+The result goes to stdout; progress, counts and warnings go to stderr. Redirecting produces a file that parses, with the status still visible in the terminal:
+
+```bash
+effect-analyze ./src/transfer.ts --format mermaid > transfer.mmd
+```
+
+`--quiet` silences the status lines themselves. Over several paths, `--format json` prints one array rather than a run of separate documents, so `| jq` works on the whole run.
+
 ## General Options
 
 | Flag | Description | Default |
@@ -51,6 +61,8 @@ Diff mode reads its two sources from the positional arguments, so `--diff` keeps
 | `--no-color` | Disable colored terminal output | color on |
 | `--quiet` | Suppress verbose status messages | off |
 | `--tsconfig <path>` | Path to a custom `tsconfig.json` | auto-detected |
+| `--extensions <list>` | Extensions discovered when walking a directory | `ts,tsx` |
+| `--max-depth <n>` | How deep a directory walk descends | `10` |
 | `--include-trivial` | Include trivial programs (schemas, thin wrappers) that are excluded by default | off |
 | `--no-metadata` | Exclude analysis metadata from JSON output | off |
 | `-h, --help` | Print help and exit | — |

--- a/apps/docs/src/content/docs/reference/diagram-fidelity.mdx
+++ b/apps/docs/src/content/docs/reference/diagram-fidelity.mdx
@@ -63,7 +63,7 @@ The command checks one file or each analyzed program in a directory. It prints t
 
 ## Match Runtime Spans
 
-The analyzer joins runtime spans to static nodes by their full nested path. These two spans form the path `transfer > debit`:
+The analyzer joins runtime spans to static nodes by their nested path. These two spans form the path `transfer > debit`:
 
 ```ts
 const program = Effect.gen(function* () {
@@ -75,6 +75,8 @@ const program = Effect.gen(function* () {
 ```
 
 Keep names literal and give sibling spans different names. Put request IDs, account IDs, and other runtime values in span attributes.
+
+A captured trace usually starts above the analyzed program, in an HTTP handler or a job runner the analyzed file never mentions. The analyzer matches the full path first, then the longest path suffix that identifies a single node, so those outer spans still resolve everything nested beneath them.
 
 ### Effect v4 spans
 
@@ -100,11 +102,38 @@ const trace = traceFromOpenTelemetry(readableSpans)
 const overlay = renderMermaidWithRuntimeTrace(ir, trace)
 ```
 
-`RuntimeOverlayResult` returns the Mermaid source and three span-ID lists:
+### Span-tree JSON
+
+Tracing tools that export a trace as a nested tree of spans go through `traceFromSpanTree()`. Each node carries a `spanId`, a `name`, a `status` of `ok`, `error` or `unset`, an optional `durationMs`, an optional `running` flag, and its `children`:
+
+```ts
+import {
+  renderMermaidWithRuntimeTrace,
+  traceFromSpanTree,
+} from "effect-analyzer"
+
+const trace = traceFromSpanTree(JSON.parse(exportedTrace))
+const overlay = renderMermaidWithRuntimeTrace(ir, trace)
+```
+
+The CLI reads that same shape from a file:
+
+```bash
+npx effect-analyze ./src/transfer.ts --format mermaid --runtime-trace ./trace.json
+```
+
+The diagram is followed by a comment line counting how the spans matched, so a reviewer or an agent can weigh the colors:
+
+```
+%% runtime overlay: 5 matched, 1 matched by suffix, 0 unmatched, 0 ambiguous
+```
+
+`RuntimeOverlayResult` returns the Mermaid source and four span-ID lists:
 
 | Field | Meaning |
 |---|---|
-| `matchedSpanIds` | The trace path identifies one static node |
+| `matchedSpanIds` | The full trace path identifies one static node |
+| `suffixMatchedSpanIds` | A path suffix identifies one static node, after dropping outer spans |
 | `unmatchedSpanIds` | The trace path identifies no static node |
 | `ambiguousSpanIds` | The trace path identifies more than one static node |
 

--- a/packages/effect-analyzer/src/capture-stdout.ts
+++ b/packages/effect-analyzer/src/capture-stdout.ts
@@ -5,8 +5,8 @@
  * clear the screen: clearing before the run blanks the last good diagram every
  * time the file is saved mid-edit.
  *
- * ponytail: swaps the global `process.stdout.write` for the duration, so it is
- * only safe while nothing else writes concurrently. Overlapping captures
+ * Swaps the global `process.stdout.write` for the duration, so it is only safe
+ * while nothing else writes concurrently. Overlapping captures
  * restore in the order they finish, so the later one hands back a function the
  * earlier one already abandoned and all output after it is swallowed. Watch
  * mode is the only caller and serializes through `makeRefreshQueue` for exactly

--- a/packages/effect-analyzer/src/cli-help.ts
+++ b/packages/effect-analyzer/src/cli-help.ts
@@ -12,8 +12,11 @@
 export const HELP_TEXT = `
 effect-analyzer - Static analysis for Effect-TS
 
-Usage: effect-analyze [PATH] [options]
+Usage: effect-analyze [PATH...] [options]
        effect-analyze <command> [options]
+
+A PATH is a file, a directory (analyzed recursively), or a glob. Quote a glob
+to let the CLI expand it: effect-analyze 'src/**/*.ts' --format mermaid
 
 Commands (a drop-in replacement for the effect-tsgo CLI):
   diagnostics              Effect language service diagnostics plus the analyzer's

--- a/packages/effect-analyzer/src/cli-help.ts
+++ b/packages/effect-analyzer/src/cli-help.ts
@@ -54,6 +54,8 @@ Options:
   -c, --compact            Compact output (no formatting)
   --pretty                 Pretty-print output (default; overrides --compact)
   --tsconfig <path>        Path to tsconfig.json for resolution (e.g. when analyzing external repo)
+  --extensions <list>      Extensions to discover when walking a directory (default: ts,tsx)
+  --max-depth <n>          How deep a directory walk descends (default: 10)
   --no-metadata            Exclude metadata from output
   --colocate               (Single file) Write analysis next to source as markdown
   --no-colocate            (Project mode) Do not write colocated files; print summary only

--- a/packages/effect-analyzer/src/cli-help.ts
+++ b/packages/effect-analyzer/src/cli-help.ts
@@ -47,6 +47,7 @@ Options:
   -o, --output <file>      Output file (default: stdout)
   -d, --direction <dir>    Mermaid diagram direction: TB | LR | BT | RL (default: TB)
   --detail <level>         Mermaid detail level: compact | standard | verbose (default: auto based on size)
+  --runtime-trace <file>   Overlay a runtime trace on --format mermaid (nested span-tree JSON)
   -c, --compact            Compact output (no formatting)
   --pretty                 Pretty-print output (default; overrides --compact)
   --tsconfig <path>        Path to tsconfig.json for resolution (e.g. when analyzing external repo)

--- a/packages/effect-analyzer/src/cli-mode-analysis.ts
+++ b/packages/effect-analyzer/src/cli-mode-analysis.ts
@@ -167,6 +167,13 @@ export const writeTestStubsForFile = (
 export const runAnalysis = (
   resolvedPath: string,
   options: CLIOptions,
+  /**
+   * Where the rendered result goes, `Console.log` by default.
+   *
+   * A run over several paths needs the pieces before they are printed: three
+   * JSON documents written one after another do not parse as one.
+   */
+  emit: (rendered: string) => Effect.Effect<void> = Console.log,
 ) =>
   Effect.gen(function* () {
     const style = createStyle(options.color && process.stdout.isTTY);
@@ -175,8 +182,12 @@ export const runAnalysis = (
     // The counts used to ignore it while the line explaining them respected
     // it, which left `--quiet` reporting "Found 2 program(s)" above a single
     // diagram with nothing saying where the other one went.
+    //
+    // Progress goes to stderr: stdout carries the diagram or the JSON, and a
+    // status line in the middle of it makes `> out.mmd` produce a file that
+    // does not parse.
     const logProgress = (message: string): Effect.Effect<void> =>
-      options.quiet ? Effect.void : Console.log(message);
+      options.quiet ? Effect.void : Console.error(message);
 
     const analyzerOptions =
       options.tsconfig !== undefined
@@ -295,7 +306,7 @@ export const runAnalysis = (
         options.quality ? programQualities : undefined,
         options.styleGuide,
       );
-      yield* Console.log(`Written: ${outputFile}`);
+      yield* Console.error(`Written: ${outputFile}`);
       return;
     }
 
@@ -561,8 +572,8 @@ export const runAnalysis = (
     const outputPath = options.output;
     if (outputPath) {
       yield* cliTry(() => fs.writeFile(outputPath, output, 'utf-8'));
-      yield* Console.log(`Output written to ${outputPath}`);
+      yield* Console.error(`Output written to ${outputPath}`);
     } else {
-      yield* Console.log(output);
+      yield* emit(output);
     }
   });

--- a/packages/effect-analyzer/src/cli-mode-analysis.ts
+++ b/packages/effect-analyzer/src/cli-mode-analysis.ts
@@ -24,7 +24,9 @@ import {
   renderStaticMermaid,
   renderPathsMermaid,
   renderEnhancedMermaid,
+  renderMermaidWithRuntimeTrace,
 } from './output/mermaid';
+import { traceFromSpanTree, type SpanTree } from './runtime-trace';
 import { renderRailwayMermaid } from './output/mermaid-railway';
 import { renderServicesMermaid } from './output/mermaid-services';
 import { renderErrorsMermaid } from './output/mermaid-errors';
@@ -395,13 +397,32 @@ export const runAnalysis = (
         break;
       }
       case 'mermaid': {
+        const traceFile = options.runtimeTrace;
+        const runtimeTrace = traceFile
+          ? traceFromSpanTree(
+              JSON.parse(
+                yield* cliTry(() => fs.readFile(resolve(traceFile), 'utf8')),
+              ) as SpanTree,
+            )
+          : undefined;
+        const mermaidOptions = {
+          direction: options.direction,
+          ...(options.detail ? { detail: options.detail } : {}),
+        };
         const diagrams: string[] = [];
         for (const ir of filteredIrs) {
-          const diagram = yield* renderMermaid(ir, {
-            direction: options.direction,
-            ...(options.detail ? { detail: options.detail } : {}),
-          });
-          diagrams.push(diagram);
+          if (runtimeTrace) {
+            const overlay = renderMermaidWithRuntimeTrace(ir, runtimeTrace, mermaidOptions);
+            diagrams.push(
+              `${overlay.mermaid}\n%% runtime overlay: ` +
+                `${overlay.matchedSpanIds.length} matched, ` +
+                `${overlay.suffixMatchedSpanIds.length} matched by suffix, ` +
+                `${overlay.unmatchedSpanIds.length} unmatched, ` +
+                `${overlay.ambiguousSpanIds.length} ambiguous`,
+            );
+            continue;
+          }
+          diagrams.push(yield* renderMermaid(ir, mermaidOptions));
         }
         output = diagrams.join('\n\n');
         break;

--- a/packages/effect-analyzer/src/cli-mode-project.ts
+++ b/packages/effect-analyzer/src/cli-mode-project.ts
@@ -61,6 +61,8 @@ export const runCoverageAuditCli = (
   Effect.gen(function* () {
     const audit = yield* runCoverageAudit(resolvedPath, {
       tsconfig: options.tsconfig,
+      extensions: options.extensions,
+      maxDepth: options.maxDepth,
       includePerFileTiming: options.perFileTiming,
       excludeFromSuspiciousZeros: options.excludeFromSuspiciousZeros,
       knownEffectInternalsRoot: options.knownEffectInternalsRoot,
@@ -121,6 +123,8 @@ export const runProjectMode = (
 
     const projectResult = yield* analyzeProject(resolvedPath, {
       tsconfig: options.tsconfig,
+      extensions: options.extensions,
+      maxDepth: options.maxDepth,
       knownEffectInternalsRoot: options.knownEffectInternalsRoot,
       buildServiceMap: options.serviceMap,
       buildArchitecture: true,

--- a/packages/effect-analyzer/src/cli-options.test.ts
+++ b/packages/effect-analyzer/src/cli-options.test.ts
@@ -272,6 +272,28 @@ describe('parseArgs', () => {
     });
   });
 
+  describe('--extensions and --max-depth', () => {
+    it('normalizes a comma-separated extension list', () => {
+      expect(opts('--extensions', 'ts,.tsx, js').extensions).toEqual(['.ts', '.tsx', '.js']);
+      expect(opts('--extensions=mts').extensions).toEqual(['.mts']);
+    });
+
+    it('leaves both unset by default, so discovery keeps its own defaults', () => {
+      expect(opts().extensions).toBeUndefined();
+      expect(opts().maxDepth).toBeUndefined();
+    });
+
+    it('rejects an empty list and a depth that cannot walk anything', () => {
+      expect(parseArgs(['src', '--extensions', ',']).errors).toHaveLength(1);
+      expect(parseArgs(['src', '--max-depth', '0']).errors).toHaveLength(1);
+      expect(parseArgs(['src', '--max-depth', 'deep']).errors).toHaveLength(1);
+    });
+
+    it('accepts a depth of one, meaning the directory itself', () => {
+      expect(opts('--max-depth', '1').maxDepth).toBe(1);
+    });
+  });
+
   describe('--tsgo', () => {
     it('defaults to tsconfig.json', () => {
       expect(opts('--tsgo').tsgoProject).toBe('tsconfig.json');

--- a/packages/effect-analyzer/src/cli-options.test.ts
+++ b/packages/effect-analyzer/src/cli-options.test.ts
@@ -280,12 +280,14 @@ describe('parseArgs', () => {
     it('consumes a following path only once a path argument has been seen', () => {
       expect(parseArgs(['src', '--tsgo', 'custom.json'])).toEqual({
         pathArg: 'src',
+        pathArgs: ['src'],
         options: expect.objectContaining({ tsgoProject: 'custom.json' }),
         errors: [],
       });
       // No path yet, so `other.ts` stays the path argument rather than the project.
       expect(parseArgs(['--tsgo', 'other.ts'])).toEqual({
         pathArg: 'other.ts',
+        pathArgs: ['other.ts'],
         options: expect.objectContaining({ tsgoProject: 'tsconfig.json' }),
         errors: [],
       });
@@ -421,6 +423,7 @@ describe('parseArgs', () => {
     it('parses an empty argv into the documented defaults', () => {
       expect(parseArgs([])).toEqual({
         pathArg: undefined,
+        pathArgs: [],
         options: expect.objectContaining({
           format: 'auto',
           pretty: true,

--- a/packages/effect-analyzer/src/cli-options.ts
+++ b/packages/effect-analyzer/src/cli-options.ts
@@ -132,6 +132,8 @@ const TEST_RUNNER_VALUES = ['vitest', 'jest', 'mocha'] as const;
 
 export function parseArgs(args: readonly string[]): {
   pathArg: string | undefined;
+  /** Every positional argument, in the order given. */
+  pathArgs: readonly string[];
   options: CLIOptions;
   errors: readonly string[];
 } {
@@ -693,5 +695,5 @@ export function parseArgs(args: readonly string[]): {
     improveExcludeRules: improveExcludeRules.length > 0 ? improveExcludeRules : undefined,
     improveMinPriority,
   };
-  return { pathArg, options, errors };
+  return { pathArg, pathArgs: positionalArgs, options, errors };
 }

--- a/packages/effect-analyzer/src/cli-options.ts
+++ b/packages/effect-analyzer/src/cli-options.ts
@@ -22,6 +22,8 @@ export interface CLIOptions {
   readonly includeMetadata: boolean;
   readonly direction: MermaidDirection;
   readonly detail: 'compact' | 'standard' | 'verbose' | undefined;
+  /** Path to a span-tree JSON trace to overlay on the mermaid diagram. */
+  readonly runtimeTrace: string | undefined;
   readonly tsconfig: string | undefined;
   readonly colocate: boolean;
   readonly noColocate: boolean;
@@ -154,6 +156,7 @@ export function parseArgs(args: readonly string[]): {
 
   let pathArg: string | undefined;
   let format: CLIOptions['format'] = 'auto';
+  let runtimeTrace: string | undefined;
   let output: string | undefined;
   let pretty = true;
   let includeMetadata = true;
@@ -323,6 +326,10 @@ export function parseArgs(args: readonly string[]): {
       } else {
         rejectValue('--detail', value, DETAIL_VALUES);
       }
+    } else if (arg === '--runtime-trace') {
+      runtimeTrace = args[++i];
+    } else if (arg.startsWith('--runtime-trace=')) {
+      runtimeTrace = arg.slice('--runtime-trace='.length);
     } else if (arg === '--tsconfig') {
       tsconfig = args[++i];
     } else if (arg.startsWith('--tsconfig=')) {
@@ -608,6 +615,7 @@ export function parseArgs(args: readonly string[]): {
     includeMetadata,
     direction,
     detail,
+    runtimeTrace,
     tsconfig,
     colocate,
     noColocate,

--- a/packages/effect-analyzer/src/cli-options.ts
+++ b/packages/effect-analyzer/src/cli-options.ts
@@ -25,6 +25,10 @@ export interface CLIOptions {
   /** Path to a span-tree JSON trace to overlay on the mermaid diagram. */
   readonly runtimeTrace: string | undefined;
   readonly tsconfig: string | undefined;
+  /** Extensions discovered when walking a directory; default `.ts`, `.tsx`. */
+  readonly extensions: readonly string[] | undefined;
+  /** How deep a directory walk descends; default 10. */
+  readonly maxDepth: number | undefined;
   readonly colocate: boolean;
   readonly noColocate: boolean;
   readonly colocateSuffix: string;
@@ -159,6 +163,8 @@ export function parseArgs(args: readonly string[]): {
   let pathArg: string | undefined;
   let format: CLIOptions['format'] = 'auto';
   let runtimeTrace: string | undefined;
+  let extensions: readonly string[] | undefined;
+  let maxDepth: number | undefined;
   let output: string | undefined;
   let pretty = true;
   let includeMetadata = true;
@@ -332,6 +338,30 @@ export function parseArgs(args: readonly string[]): {
       runtimeTrace = args[++i];
     } else if (arg.startsWith('--runtime-trace=')) {
       runtimeTrace = arg.slice('--runtime-trace='.length);
+    } else if (arg === '--extensions' || arg.startsWith('--extensions=')) {
+      const value = arg.startsWith('--extensions=')
+        ? arg.slice('--extensions='.length)
+        : args[++i];
+      const parsed = (value ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+        .map((entry) => (entry.startsWith('.') ? entry : `.${entry}`));
+      if (parsed.length === 0) {
+        rejectValue('--extensions', value);
+      } else {
+        extensions = parsed;
+      }
+    } else if (arg === '--max-depth' || arg.startsWith('--max-depth=')) {
+      const value = arg.startsWith('--max-depth=')
+        ? arg.slice('--max-depth='.length)
+        : args[++i];
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        rejectValue('--max-depth', value);
+      } else {
+        maxDepth = parsed;
+      }
     } else if (arg === '--tsconfig') {
       tsconfig = args[++i];
     } else if (arg.startsWith('--tsconfig=')) {
@@ -618,6 +648,8 @@ export function parseArgs(args: readonly string[]): {
     direction,
     detail,
     runtimeTrace,
+    extensions,
+    maxDepth,
     tsconfig,
     colocate,
     noColocate,

--- a/packages/effect-analyzer/src/cli-support.ts
+++ b/packages/effect-analyzer/src/cli-support.ts
@@ -8,7 +8,7 @@
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
-import { isAbsolute, resolve } from 'path';
+import { isAbsolute, resolve, sep } from 'path';
 import { Console, Data, Effect, Option } from 'effect';
 import type { LintFinding } from './lint-session';
 
@@ -85,6 +85,66 @@ export const resolveCliPath = (inputPath: string | undefined): string => {
 
   return fromCurrent;
 };
+
+/** Shell metacharacters that make an argument a pattern rather than a path. */
+const GLOB_MAGIC = /[*?[\]{}]/;
+
+/** Directories a pattern should never reach into, matching project discovery. */
+const isIgnoredMatch = (path: string): boolean =>
+  path.includes(`${sep}node_modules${sep}`) || path.includes(`${sep}.git${sep}`);
+
+/**
+ * Bases a relative pattern is tried against, in order.
+ *
+ * The same fallbacks `resolveCliPath` uses: a package script can run the CLI
+ * from a directory the user never typed, and `INIT_CWD` is where they were.
+ */
+const patternBases = (): readonly string[] => [
+  ...new Set(
+    [process.cwd(), process.env.INIT_CWD, process.env.PWD, process.env.OLDPWD].filter(
+      (base): base is string => typeof base === 'string' && base.trim().length > 0,
+    ),
+  ),
+];
+
+const globPattern = async (pattern: string): Promise<readonly string[]> => {
+  for (const base of isAbsolute(pattern) ? [''] : patternBases()) {
+    const matches: string[] = [];
+    for await (const match of fs.glob(pattern, base === '' ? {} : { cwd: base })) {
+      const full = resolve(base, match);
+      if (!isIgnoredMatch(full)) matches.push(full);
+    }
+    if (matches.length > 0) return matches.sort((left, right) => left.localeCompare(right));
+  }
+  return [];
+};
+
+/**
+ * Expand the glob patterns among the CLI's positional arguments.
+ *
+ * A shell expands an unquoted pattern before the CLI sees it; a quoted one
+ * arrives verbatim, and `fs.glob` is Node's own, so this needs no dependency.
+ * Arguments without pattern characters are returned untouched, leaving plain
+ * path resolution and its "Path not found" message exactly as they were.
+ */
+export const expandCliPaths = (
+  patterns: readonly string[],
+): Effect.Effect<readonly string[], CliError> =>
+  Effect.gen(function* () {
+    const expanded: string[] = [];
+    for (const pattern of patterns) {
+      if (!GLOB_MAGIC.test(pattern)) {
+        expanded.push(pattern);
+        continue;
+      }
+      const matches = yield* cliTry(() => globPattern(pattern));
+      if (matches.length === 0) {
+        return yield* cliFail(`No files matched: ${pattern}`);
+      }
+      expanded.push(...matches);
+    }
+    return [...new Set(expanded)];
+  });
 
 /** Best-effort open of a file in the OS default application. */
 export const openInBrowser = (file: string): Effect.Effect<void> =>

--- a/packages/effect-analyzer/src/cli.multi-path.test.ts
+++ b/packages/effect-analyzer/src/cli.multi-path.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const SOURCE = (name: string) => `
+import { Effect } from 'effect';
+export const ${name} = Effect.gen(function* () {
+  yield* Effect.succeed('ok');
+  yield* Effect.log('done');
+});
+`;
+
+let root: string;
+
+const cli = resolve(__dirname, '..', 'dist', 'cli.js');
+
+const runCli = (args: readonly string[]) =>
+  spawnSync(process.execPath, [cli, ...args], { cwd: root, encoding: 'utf8' });
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'effect-analyze-multi-'));
+  mkdirSync(join(root, 'src', 'nested'), { recursive: true });
+  writeFileSync(
+    join(root, 'tsconfig.json'),
+    '{"compilerOptions":{"target":"ES2022","module":"ESNext","moduleResolution":"bundler","strict":true}}',
+    'utf8',
+  );
+  writeFileSync(join(root, 'src', 'checkout.ts'), SOURCE('checkout'), 'utf8');
+  writeFileSync(join(root, 'src', 'refund.ts'), SOURCE('refund'), 'utf8');
+  writeFileSync(join(root, 'src', 'nested', 'ship.ts'), SOURCE('ship'), 'utf8');
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe('cli multiple paths', () => {
+  it('analyzes every path a shell expanded, not just the first', () => {
+    const result = runCli([
+      join('src', 'checkout.ts'),
+      join('src', 'refund.ts'),
+      '--format',
+      'mermaid',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('checkout.ts');
+    expect(result.stdout).toContain('refund.ts');
+    expect(result.stdout.match(/flowchart/g)).toHaveLength(2);
+  });
+
+  it('expands a quoted glob itself, recursively', () => {
+    const result = runCli(['src/**/*.ts', '--format', 'mermaid', '--quiet']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.match(/flowchart/g)).toHaveLength(3);
+  });
+
+  it('fails when a pattern matches nothing', () => {
+    const result = runCli(['src/**/*.missing', '--format', 'mermaid']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('No files matched: src/**/*.missing');
+  });
+
+  it('refuses a mode that cannot mean anything over a list', () => {
+    const result = runCli([
+      join('src', 'checkout.ts'),
+      join('src', 'refund.ts'),
+      '--format',
+      'mermaid',
+      '-o',
+      'out.mmd',
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--output writes one file');
+  });
+
+  it('refuses extra paths for a mode that reads one path', () => {
+    const result = runCli([
+      join('src', 'checkout.ts'),
+      join('src', 'refund.ts'),
+      '--agent-report',
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Expected one path, received 2');
+  });
+
+  it('still sends a lone directory through project mode', () => {
+    const result = runCli(['src', '--format', 'mermaid', '--quiet', '--no-colocate']);
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/effect-analyzer/src/cli.multi-path.test.ts
+++ b/packages/effect-analyzer/src/cli.multi-path.test.ts
@@ -46,9 +46,11 @@ describe('cli multiple paths', () => {
     ]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('checkout.ts');
-    expect(result.stdout).toContain('refund.ts');
+    expect(result.stderr).toContain('checkout.ts');
+    expect(result.stderr).toContain('refund.ts');
     expect(result.stdout.match(/flowchart/g)).toHaveLength(2);
+    // Redirecting stdout has to give a file that parses, so no status text.
+    expect(result.stdout).not.toContain('Analyzing');
   });
 
   it('expands a quoted glob itself, recursively', () => {
@@ -56,6 +58,20 @@ describe('cli multiple paths', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.match(/flowchart/g)).toHaveLength(3);
+  });
+
+  it('prints one JSON document for the whole run', () => {
+    const result = runCli([
+      join('src', 'checkout.ts'),
+      join('src', 'refund.ts'),
+      '--format',
+      'json',
+    ]);
+
+    expect(result.status).toBe(0);
+    const parsed: unknown = JSON.parse(result.stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
   });
 
   it('fails when a pattern matches nothing', () => {

--- a/packages/effect-analyzer/src/cli.quiet.test.ts
+++ b/packages/effect-analyzer/src/cli.quiet.test.ts
@@ -17,7 +17,7 @@ export const checkout = Effect.gen(function* () {
 export const refundOrder = Effect.succeed('refunded');
 `;
 
-const runCli = (root: string, extraArgs: readonly string[]): string => {
+const runCli = (root: string, extraArgs: readonly string[]) => {
   const repoRoot = resolve(__dirname, '..');
   const result = spawnSync(
     process.execPath,
@@ -31,7 +31,7 @@ const runCli = (root: string, extraArgs: readonly string[]): string => {
     { cwd: repoRoot, encoding: 'utf8' },
   );
   expect(result.status).toBe(0);
-  return result.stdout;
+  return { stdout: result.stdout, stderr: result.stderr };
 };
 
 describe('cli --quiet', () => {
@@ -41,15 +41,17 @@ describe('cli --quiet', () => {
       writeFileSync(join(root, 'program.ts'), SOURCE, 'utf8');
 
       // Without --quiet both lines appear, so the count is accounted for.
+      // They belong on stderr, where they cannot corrupt a redirected diagram.
       const loud = runCli(root, []);
-      expect(loud).toContain('Found 2 program(s)');
-      expect(loud).toContain('trivial program(s)');
+      expect(loud.stderr).toContain('Found 2 program(s)');
+      expect(loud.stderr).toContain('trivial program(s)');
+      expect(loud.stdout).not.toContain('program(s)');
 
       // With --quiet neither should: "minimal output" cannot mean keeping the
       // number that raises the question and dropping the answer.
       const quiet = runCli(root, ['--quiet']);
-      expect(quiet).toContain('flowchart');
-      expect(quiet).not.toContain('program(s)');
+      expect(quiet.stdout).toContain('flowchart');
+      expect(quiet.stderr).not.toContain('program(s)');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/effect-analyzer/src/cli.ts
+++ b/packages/effect-analyzer/src/cli.ts
@@ -108,12 +108,23 @@ const runManyPaths = (paths: readonly string[], options: CLIOptions) =>
       }
     }
 
+    // JSON is collected and printed as one array: several documents in a row
+    // are not a document. Every other format concatenates as it always has.
+    const documents: string[] = [];
+    const collect = options.format === 'json'
+      ? (rendered: string) => Effect.sync(() => void documents.push(rendered))
+      : undefined;
+
     for (const path of paths) {
       const resolved = resolveCliPath(path);
       if (!options.quiet) {
-        yield* Console.log(`Analyzing ${resolved}...`);
+        yield* Console.error(`Analyzing ${resolved}...`);
       }
-      yield* runAnalysis(resolved, options);
+      yield* runAnalysis(resolved, options, collect);
+    }
+
+    if (collect) {
+      yield* Console.log(`[${documents.join(',')}]`);
     }
   });
 
@@ -320,7 +331,7 @@ const main = Effect.gen(function* () {
   }
 
   if (!options.quiet) {
-    yield* Console.log(`Analyzing ${resolvedPath}...`);
+    yield* Console.error(`Analyzing ${resolvedPath}...`);
   }
   yield* runAnalysis(resolvedPath, options);
 

--- a/packages/effect-analyzer/src/cli.ts
+++ b/packages/effect-analyzer/src/cli.ts
@@ -18,8 +18,8 @@ import * as fs from 'node:fs/promises';
 import { Effect, Console, Exit, Option } from 'effect';
 import { analyzeStateMachines } from './state-machine';
 import { runWatchMode } from './watch-mode';
-import { cliFail, cliTry, resolveCliPath } from './cli-support';
-import { parseArgs } from './cli-options';
+import { cliFail, cliTry, expandCliPaths, resolveCliPath } from './cli-support';
+import { parseArgs, type CLIOptions } from './cli-options';
 import {
   isProxiedTsgoCommand,
   proxyTsgoCommand,
@@ -56,6 +56,67 @@ import { detectServiceCycles } from './service-cycles';
 
 
 
+/** Formats whose renderers take a single entry point, not a list of files. */
+const SINGLE_PATH_FORMATS = new Set<CLIOptions['format']>([
+  'migration',
+  'api-docs',
+  'openapi-paths',
+  'openapi-runtime',
+  'json-schema',
+  'mermaid-statechart',
+  'svg-statechart',
+  'statechart-html',
+  'xstate-config',
+  'statechart-coverage',
+]);
+
+/**
+ * Analyze every path a shell or a pattern produced.
+ *
+ * Modes that read a directory, follow one file, or write one output file cannot
+ * mean anything over a list, so they are refused with the reason rather than
+ * run against whichever path happened to come first.
+ */
+const runManyPaths = (paths: readonly string[], options: CLIOptions) =>
+  Effect.gen(function* () {
+    const refusal =
+      options.output
+        ? '--output writes one file. Drop it, or pass one path.'
+        : options.watch
+          ? '--watch follows one path.'
+          : options.coverageAudit || options.serviceCycles
+            ? '--coverage-audit and --service-cycles read one directory.'
+            : options.entryPoints || options.configLeaks || options.cliCommands
+              ? '--entry-points, --config-leaks and --cli-commands read one file.'
+              : SINGLE_PATH_FORMATS.has(options.format)
+                ? `--format ${options.format} reads one path.`
+                : undefined;
+    if (refusal) {
+      return yield* cliFail(`${String(paths.length)} paths given. ${refusal}`);
+    }
+
+    for (const path of paths) {
+      const resolved = resolveCliPath(path);
+      const stats = yield* cliTry(() => fs.stat(resolved)).pipe(Effect.option);
+      if (Option.isNone(stats)) {
+        return yield* cliFail(`Path not found: ${resolved}`);
+      }
+      if (stats.value.isDirectory()) {
+        return yield* cliFail(
+          `${resolved} is a directory. Analyze a directory on its own, not alongside other paths.`,
+        );
+      }
+    }
+
+    for (const path of paths) {
+      const resolved = resolveCliPath(path);
+      if (!options.quiet) {
+        yield* Console.log(`Analyzing ${resolved}...`);
+      }
+      yield* runAnalysis(resolved, options);
+    }
+  });
+
 const main = Effect.gen(function* () {
   const args = process.argv.slice(2);
 
@@ -78,10 +139,30 @@ const main = Effect.gen(function* () {
     return Exit.succeed(undefined);
   }
 
-  const { pathArg, options, errors: argErrors } = parseArgs(args);
+  const { pathArg, pathArgs, options, errors: argErrors } = parseArgs(args);
 
   if (argErrors.length > 0) {
     return yield* cliFail(argErrors.join('\n'));
+  }
+
+  // `--diff` reads the positionals itself; every other mode reached before path
+  // resolution takes one path, so extra ones are refused rather than dropped.
+  const takesOnePath =
+    options.lintSource ||
+    options.agentReport ||
+    options.errorChannel ||
+    options.serviceHealth ||
+    options.performance ||
+    options.coupling ||
+    options.improve ||
+    options.listRules ||
+    options.indexRules ||
+    options.searchRules !== undefined ||
+    options.explainRule !== undefined;
+  if (pathArgs.length > 1 && !options.diff && takesOnePath) {
+    return yield* cliFail(
+      `Expected one path, received ${String(pathArgs.length)}: ${pathArgs.join(', ')}`,
+    );
   }
 
   if (options.importSession) {
@@ -114,7 +195,14 @@ const main = Effect.gen(function* () {
     return Exit.succeed(undefined);
   }
 
-  const resolvedPath = resolveCliPath(pathArg);
+  const paths = yield* expandCliPaths(pathArgs);
+
+  if (paths.length > 1) {
+    yield* runManyPaths(paths, options);
+    return Exit.succeed(undefined);
+  }
+
+  const resolvedPath = resolveCliPath(paths[0] ?? pathArg);
 
   const s = yield* cliTry(() => fs.stat(resolvedPath)).pipe(
     Effect.option,

--- a/packages/effect-analyzer/src/index.ts
+++ b/packages/effect-analyzer/src/index.ts
@@ -24,11 +24,14 @@ export {
 
 export {
   traceFromEffectSpans,
+  traceFromSpanTree,
   traceFromOpenTelemetry,
   type RuntimeTrace,
   type RuntimeTraceSpan,
   type RuntimeSpanStatus,
   type OpenTelemetryReadableSpan,
+  type SpanTree,
+  type SpanTreeNode,
 } from './runtime-trace';
 
 export {

--- a/packages/effect-analyzer/src/lint-session.ts
+++ b/packages/effect-analyzer/src/lint-session.ts
@@ -300,7 +300,7 @@ export const runSourceLintScan = async (
   }
 
   // Type-aware rules from the official Effect language service, when available.
-  // ponytail: tsgo diagnostics bypass our disable pragmas — tsgo has its own
+  // tsgo diagnostics bypass our disable pragmas — tsgo has its own
   // suppression story; wire the two together only if users actually ask.
   let tsgo: TsgoCoverage | undefined;
   if (options.tsgoProject) {

--- a/packages/effect-analyzer/src/output/mermaid.ts
+++ b/packages/effect-analyzer/src/output/mermaid.ts
@@ -1138,7 +1138,13 @@ const TRACE_STYLES: Record<RuntimeSpanStatus, string> = {
 
 export interface RuntimeOverlayResult {
   readonly mermaid: string;
+  /** Span path matched a static node exactly, root segment included. */
   readonly matchedSpanIds: readonly string[];
+  /**
+   * Span matched only after dropping leading path segments. Weaker evidence
+   * than an exact match, so it is reported apart from one.
+   */
+  readonly suffixMatchedSpanIds: readonly string[];
   readonly unmatchedSpanIds: readonly string[];
   readonly ambiguousSpanIds: readonly string[];
 }
@@ -1152,13 +1158,26 @@ export function renderMermaidWithRuntimeTrace(
   const { lines, context } = renderStaticMermaidInternal(ir, options);
   const irIndex = indexIR(ir);
   const matchedSpanIds: string[] = [];
+  const suffixMatchedSpanIds: string[] = [];
   const unmatchedSpanIds: string[] = [];
   const ambiguousSpanIds: string[] = [];
   const usedStatuses = new Set<RuntimeSpanStatus>();
   const assignments: string[] = [];
 
   for (const span of trace.spans) {
-    const staticIds = irIndex.idsBySpanPath.get(spanPathKey(span.path)) ?? [];
+    // The IR of one program cannot contain spans opened above it — an HTTP
+    // handler, a job runner, the caller's own `withSpan` — but a real trace
+    // always carries them. Try the full path first, then progressively shorter
+    // suffixes, so an outer ancestor does not lose every span beneath it.
+    let staticIds: readonly string[] = [];
+    let exact = false;
+    for (let start = 0; start < span.path.length; start++) {
+      const ids = irIndex.idsBySpanPath.get(spanPathKey(span.path.slice(start)));
+      if (!ids || ids.length === 0) continue;
+      staticIds = ids;
+      exact = start === 0;
+      break;
+    }
     if (staticIds.length === 0) {
       unmatchedSpanIds.push(span.spanId);
       continue;
@@ -1173,7 +1192,7 @@ export function renderMermaidWithRuntimeTrace(
       unmatchedSpanIds.push(span.spanId);
       continue;
     }
-    matchedSpanIds.push(span.spanId);
+    (exact ? matchedSpanIds : suffixMatchedSpanIds).push(span.spanId);
     usedStatuses.add(span.status);
     assignments.push(`  class ${mermaidId} trace_${span.status}`);
   }
@@ -1186,7 +1205,13 @@ export function renderMermaidWithRuntimeTrace(
     lines.push(...assignments);
   }
 
-  return { mermaid: lines.join('\n'), matchedSpanIds, unmatchedSpanIds, ambiguousSpanIds };
+  return {
+    mermaid: lines.join('\n'),
+    matchedSpanIds,
+    suffixMatchedSpanIds,
+    unmatchedSpanIds,
+    ambiguousSpanIds,
+  };
 }
 
 /**

--- a/packages/effect-analyzer/src/runtime-trace.test.ts
+++ b/packages/effect-analyzer/src/runtime-trace.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Effect } from 'effect';
+import { analyze } from './analyze';
+import { traceFromSpanTree } from './runtime-trace';
+import { renderMermaidWithRuntimeTrace } from './output/mermaid';
+
+describe('traceFromSpanTree', () => {
+  it('derives span paths from the nested tree and maps status', () => {
+    const trace = traceFromSpanTree({
+      spans: [
+        {
+          spanId: 'a',
+          name: 'transfer',
+          status: 'error',
+          durationMs: 12,
+          running: false,
+          children: [
+            { spanId: 'b', name: 'debit', status: 'ok', durationMs: 3, children: [] },
+            { spanId: 'c', name: 'credit', status: 'unset', running: true, durationMs: null },
+          ],
+        },
+      ],
+    });
+
+    expect(trace.spans).toEqual([
+      { spanId: 'a', name: 'transfer', status: 'error', durationMs: 12, path: ['transfer'] },
+      {
+        spanId: 'b',
+        parentSpanId: 'a',
+        name: 'debit',
+        status: 'success',
+        durationMs: 3,
+        path: ['transfer', 'debit'],
+      },
+      {
+        spanId: 'c',
+        parentSpanId: 'a',
+        name: 'credit',
+        status: 'running',
+        path: ['transfer', 'credit'],
+      },
+    ]);
+  });
+
+  it('overlays onto a static diagram by span path', async () => {
+    const ir = await Effect.runPromise(
+      analyze.source(`
+        import { Effect } from "effect";
+
+        export const program = Effect.gen(function* () {
+          yield* Effect.succeed(1).pipe(Effect.withSpan("debit"));
+        }).pipe(Effect.withSpan("transfer"));
+      `).single,
+    );
+
+    const overlay = renderMermaidWithRuntimeTrace(
+      ir,
+      traceFromSpanTree({
+        spans: [
+          {
+            spanId: 'a',
+            name: 'transfer',
+            status: 'ok',
+            children: [{ spanId: 'b', name: 'debit', status: 'error' }],
+          },
+        ],
+      }),
+    );
+
+    // "transfer" wraps the whole program, so it has no static node of its own;
+    // "debit" still matches once its ancestor segment is dropped.
+    expect(overlay.suffixMatchedSpanIds).toEqual(['b']);
+    expect(overlay.unmatchedSpanIds).toEqual(['a']);
+    expect(overlay.ambiguousSpanIds).toEqual([]);
+    expect(overlay.mermaid).toContain('trace_error');
+  });
+});

--- a/packages/effect-analyzer/src/runtime-trace.ts
+++ b/packages/effect-analyzer/src/runtime-trace.ts
@@ -89,3 +89,38 @@ export const traceFromOpenTelemetry = (
     return durationMs === undefined ? {} : { durationMs };
   })(),
 })));
+
+/** One node of a nested span-tree JSON export. */
+export interface SpanTreeNode {
+  readonly spanId: string;
+  readonly name: string;
+  readonly status: 'ok' | 'error' | 'unset';
+  readonly durationMs?: number | null | undefined;
+  readonly running?: boolean | undefined;
+  readonly children?: readonly SpanTreeNode[] | undefined;
+}
+
+export interface SpanTree {
+  readonly spans: readonly SpanTreeNode[];
+}
+
+/** Adapter for tracing tools that export a trace as a nested span tree. */
+export const traceFromSpanTree = (trace: SpanTree): RuntimeTrace => {
+  const flat: FlatSpan[] = [];
+  const walk = (node: SpanTreeNode, parentSpanId?: string): void => {
+    flat.push({
+      spanId: node.spanId,
+      ...(parentSpanId ? { parentSpanId } : {}),
+      name: node.name,
+      status: node.running === true
+        ? 'running'
+        : node.status === 'error'
+          ? 'error'
+          : 'success',
+      ...(typeof node.durationMs === 'number' ? { durationMs: node.durationMs } : {}),
+    });
+    for (const child of node.children ?? []) walk(child, node.spanId);
+  };
+  for (const root of trace.spans) walk(root);
+  return addPaths(flat);
+};


### PR DESCRIPTION
Developer-experience work on the `effect-analyze` CLI.

## Output streams

The rendered result goes to stdout; progress, counts and `Output written to` go to stderr. Redirecting now produces a file that parses, with the status still visible in the terminal:

```bash
effect-analyze ./src/transfer.ts --format mermaid > transfer.mmd
```

Before, that file began with `Analyzing …` and `Found 1 program(s)`, and `--quiet` was the only way out. `--quiet` still silences the status lines themselves.

A run over several paths with `--format json` prints one array rather than a run of separate documents, so `| jq` reads the whole run.

## Multiple paths and globs

`effect-analyze src/a.ts src/b.ts` analyzes each file in turn, so an unquoted shell glob works, and a quoted glob such as `'src/**/*.ts'` is expanded by the CLI itself through `fs.glob` — no new dependency. A pattern that matches nothing is reported rather than run as an empty analysis.

Only the first positional argument was read before, so extra paths were dropped without a word. Modes that read one directory (`--coverage-audit`, `--service-cycles`), follow one file (`--watch`, `--entry-points`), or write one output file (`--output`) now name the reason:

```bash
$ effect-analyze src/transfer.ts src/refund.ts -o diagram.mmd
Error: 2 paths given. --output writes one file. Drop it, or pass one path.
```

Diff mode still reads its two sources from the positional arguments.

## Directory walk

`--extensions <list>` and `--max-depth <n>` expose the walk's discovery rules. `analyzeProject` and `runCoverageAudit` already accepted both, but nothing on the command line could reach them, so `.ts`/`.tsx` and ten levels were fixed.

## Runtime trace overlay

`--runtime-trace <file>` colors a `--format mermaid` diagram with a captured trace, then prints a line counting how the spans matched so a reviewer or an agent can weigh the colors:

```
%% runtime overlay: 5 matched, 1 matched by suffix, 0 unmatched, 0 ambiguous
```

`traceFromSpanTree()` decodes traces exported as a nested span tree, alongside the existing `traceFromEffectSpans()` and `traceFromOpenTelemetry()` adapters.

Matching resolves the longest unique path suffix. A captured trace starts above the analyzed program, in an HTTP handler or a job runner the analyzed file never mentions, and matching by suffix lets those outer spans light up everything that ran beneath them. `RuntimeOverlayResult` reports suffix matches in their own list, apart from exact ones, so the evidence behind each color stays visible.

## Also

- Docs: `reference/cli.mdx` (paths, output streams, new flags), `reference/api.mdx`, `reference/diagram-fidelity.mdx`, and the CLI's own `--help`.
- Skill: Paths, Output Streams and Runtime Overlay sections, plus the new flags.
- Tests: `src/cli.multi-path.test.ts` and `src/runtime-trace.test.ts` are new; the stream split is pinned in `src/cli.quiet.test.ts`. Full suite green, 1589 tests.