### PR TITLE
feat(cli): add --version and reject unknown flags

### DIFF
--- a/.changeset/brave-pandas-shave.md
+++ b/.changeset/brave-pandas-shave.md
@@ -1,0 +1,15 @@
+---
+'effect-analyzer': patch
+---
+
+`--version`/`-v` prints the analyzer version, and an unrecognized flag is
+reported as an error.
+
+Mermaid node labels collapse whitespace runs to a single space, so a label built
+from wrapped source stays on one line.
+
+`--assert-diagram-fidelity` requires at least one program to check.
+
+`analyze().single` names the programs it found and points at `.named()` and
+`.all`. `effect-analyzer/package.json` is exported, and the `effect` peer range
+moves to `^4.0.0-rc.112`.

--- a/.claude/skills/effect-analyzer/SKILL.md
+++ b/.claude/skills/effect-analyzer/SKILL.md
@@ -58,6 +58,14 @@ effect-analyze [PATH] [options]
 
 PATH defaults to `.` (current directory). When PATH is a directory, analyzes all TypeScript files and writes colocated `.effect-analysis.md` next to each file containing Effect programs.
 
+`-h, --help` and `-v, --version` print and exit 0 (`cli-help.ts`; the version is
+read through the package's own `./package.json` export, so it resolves the same
+from `src` and `dist`). Any other argument starting with `-` that no branch of
+`parseArgs` claims becomes an `Unknown option: <flag>` error. The default path
+is `.`, so a flag that fell through instead would analyze the whole current
+directory and write a report beside every file. Add a new flag to `parseArgs`
+and `HELP_TEXT` together.
+
 ### Paths
 
 A path argument is a file, a directory (walked for `.ts`/`.tsx`, skipping `node_modules` and `.git`, depth 10), or a glob. Several paths analyze in turn, so an unquoted shell glob works; a quoted glob is expanded by the CLI itself through `expandCliPaths` (`cli-support.ts`, backed by `fs.glob`). A pattern matching nothing fails with `No files matched: <pattern>`.
@@ -325,6 +333,12 @@ import {
   computeProgramDiagramQuality, buildTopOffendersReport,
 } from 'effect-analyzer/diagram';
 ```
+
+Every `mermaid-*.ts` renderer escapes node labels through the shared
+`escapeMermaidLabel` (`analysis-utils.ts`), which collapses whitespace runs to a
+single space — labels are built from source text that wraps across lines, and a
+raw newline inside `["..."]` will not parse. `mermaid.ts` keeps its own escape
+because it substitutes characters rather than entity-encoding them.
 
 ## Quick Reference
 

--- a/apps/docs/src/content/docs/installation.mdx
+++ b/apps/docs/src/content/docs/installation.mdx
@@ -48,9 +48,11 @@ Confirm everything is set up correctly:
 
 ```bash
 npx effect-analyze --help
+npx effect-analyze --version
 ```
 
-You should see the CLI help output listing all available flags and formats.
+You should see the CLI help output listing all available flags and formats,
+and the installed version.
 
 ## TypeScript Configuration
 

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -101,7 +101,7 @@ The fluent API methods available on `analyze(path)` and `analyze.source(code)`:
 
 | Method | Description |
 |---|---|
-| `.single` | Returns exactly one program (fails if zero or multiple) |
+| `.single` | Returns exactly one program (fails if zero or multiple; the failure names the programs found and points at `.named()` and `.all`) |
 | `.singleOption` | Returns `Option<IR>` - `None` if zero programs, fails if multiple |
 | `.all` | Returns all programs as an array |
 | `.named(name)` | Returns the program matching the given name |

--- a/apps/docs/src/content/docs/reference/cli.mdx
+++ b/apps/docs/src/content/docs/reference/cli.mdx
@@ -66,6 +66,14 @@ effect-analyze ./src/transfer.ts --format mermaid > transfer.mmd
 | `--include-trivial` | Include trivial programs (schemas, thin wrappers) that are excluded by default | off |
 | `--no-metadata` | Exclude analysis metadata from JSON output | off |
 | `-h, --help` | Print help and exit | — |
+| `-v, --version` | Print the analyzer version and exit | — |
+
+An unrecognised flag is an error, not a positional path:
+
+```bash
+$ effect-analyze ./src --nope
+Error: Unknown option: --nope. See --help for the flag list.
+```
 
 An unrecognised value for a flag with a fixed set of choices (`--format`, `--direction`, `--detail`, `--profile`, `--test-runner`, `--improve-min-priority`) is an error, not a fallback to the default:
 

--- a/apps/docs/src/content/docs/reference/diagram-fidelity.mdx
+++ b/apps/docs/src/content/docs/reference/diagram-fidelity.mdx
@@ -61,6 +61,10 @@ npx effect-analyze ./src --assert-diagram-fidelity
 
 The command checks one file or each analyzed program in a directory. It prints the findings and exits with code 1 when any report has `exact: false`.
 
+The assertion needs at least one program to check, so it also exits 1 when
+filtering leaves nothing — for example a file whose programs are all trivial.
+Pass `--include-trivial` to include them.
+
 ## Match Runtime Spans
 
 The analyzer joins runtime spans to static nodes by their nested path. These two spans form the path `transfer > debit`:

--- a/packages/effect-analyzer/README.md
+++ b/packages/effect-analyzer/README.md
@@ -14,6 +14,7 @@ effect-analyzer parses your source with [ts-morph](https://ts-morph.com/) and th
 
 ```bash
 npm install -D effect-analyzer
+npx effect-analyze --version
 ```
 
 Effect v4 is the only supported Effect release. `ts-morph` is bundled automatically.
@@ -467,7 +468,9 @@ const overlay = renderMermaidWithRuntimeTrace(ir, trace)
 ```
 
 Use `--assert-diagram-fidelity` in CI to reject unresolved, opaque, dynamic-span,
-or ambiguous-span nodes.
+or ambiguous-span nodes. It needs at least one program to check, so it also
+exits 1 when filtering leaves none — pass `--include-trivial` for a file whose
+programs are all trivial.
 
 [Full API reference →](https://jagreehal.github.io/effect-analyzer/reference/api/)
 

--- a/packages/effect-analyzer/package.json
+++ b/packages/effect-analyzer/package.json
@@ -13,6 +13,7 @@
     "effect-analyze": "./dist/cli.js"
   },
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
@@ -93,7 +94,7 @@
   },
   "homepage": "https://github.com/jagreehal/effect-analyzer/tree/main/packages/effect-analyzer#readme",
   "peerDependencies": {
-    "effect": "^4.0.0-beta.101"
+    "effect": "^4.0.0-rc.112"
   },
   "peerDependenciesMeta": {
     "effect": {

--- a/packages/effect-analyzer/src/analysis-utils.ts
+++ b/packages/effect-analyzer/src/analysis-utils.ts
@@ -628,6 +628,20 @@ export function truncateDisplayText(s: string, max: number = DEFAULT_LABEL_MAX):
 const truncate = truncateDisplayText;
 
 /**
+ * Escape a label for a Mermaid node. Labels come from source text that may wrap
+ * across lines, so whitespace runs collapse to a single space.
+ */
+export function escapeMermaidLabel(text: string): string {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/"/g, '#quot;')
+    .replace(/</g, '#lt;')
+    .replace(/>/g, '#gt;')
+    .replace(/\(/g, '#lpar;')
+    .replace(/\)/g, '#rpar;');
+}
+
+/**
  * Extract a clean function name from a callee expression.
  *
  * For known Effect namespaces (Effect, Schema, Layer, etc.), strips the prefix:

--- a/packages/effect-analyzer/src/analyze-source.ts
+++ b/packages/effect-analyzer/src/analyze-source.ts
@@ -29,7 +29,9 @@ const createResult = (
       return yield* Effect.fail(
         new AnalysisError(
           'NOT_SINGLE_PROGRAM',
-          `Expected exactly 1 program, found ${String(programs.length)}`,
+          `Expected exactly 1 program, found ${String(programs.length)}: ` +
+            `${programs.map((p) => p.root.programName).join(', ')}. ` +
+            'Use .named(name) to pick one, or .all for every program.',
         ),
       );
     }),

--- a/packages/effect-analyzer/src/analyze.ts
+++ b/packages/effect-analyzer/src/analyze.ts
@@ -92,7 +92,9 @@ const createResult = (
       return yield* Effect.fail(
         new AnalysisError(
           'NOT_SINGLE_PROGRAM',
-          `Expected exactly 1 program, found ${String(programs.length)}`,
+          `Expected exactly 1 program, found ${String(programs.length)}: ` +
+            `${programs.map((p) => p.root.programName).join(', ')}. ` +
+            'Use .named(name) to pick one, or .all for every program.',
         ),
       );
     }),

--- a/packages/effect-analyzer/src/cli-help.ts
+++ b/packages/effect-analyzer/src/cli-help.ts
@@ -9,6 +9,8 @@
  * drift apart in the first place.
  */
 
+import { createRequire } from 'node:module';
+
 export const HELP_TEXT = `
 effect-analyzer - Static analysis for Effect-TS
 
@@ -142,6 +144,7 @@ Options:
   --improve-exclude-rule <rule>  Exclude fixes for this rule (repeatable)
   --improve-min-priority <P0|P1|P2|P3>  Minimum priority level to include
   -h, --help               Show this help message
+  -v, --version            Print the analyzer version
 
 Examples:
   npx effect-analyzer                    # Analyze current directory; write colocated .md (gold tier)
@@ -177,4 +180,12 @@ Examples:
 
 export const printHelp = (): void => {
   process.stdout.write(HELP_TEXT + '\n');
+};
+
+export const printVersion = (): void => {
+  // Resolved through the package's own exports, so it works from dist and src.
+  const { version } = createRequire(import.meta.url)(
+    'effect-analyzer/package.json',
+  ) as { version: string };
+  process.stdout.write(version + '\n');
 };

--- a/packages/effect-analyzer/src/cli-mode-analysis.ts
+++ b/packages/effect-analyzer/src/cli-mode-analysis.ts
@@ -263,6 +263,12 @@ export const runAnalysis = (
     }
 
     if (options.assertDiagramFidelity) {
+      if (filteredIrs.length === 0) {
+        return yield* cliFail(
+          'Diagram fidelity assertion checked no programs. ' +
+            'Nothing was left after filtering — pass --include-trivial, or point at a file with an Effect program.',
+        );
+      }
       const reports = filteredIrs.map((ir) => ({
         programName: ir.root.programName,
         report: computeDiagramFidelity(ir),

--- a/packages/effect-analyzer/src/cli-options.test.ts
+++ b/packages/effect-analyzer/src/cli-options.test.ts
@@ -272,6 +272,18 @@ describe('parseArgs', () => {
     });
   });
 
+  describe('unknown flags', () => {
+    it('refuses an unrecognized flag instead of analyzing with the defaults', () => {
+      expect(parseArgs(['--nope']).errors).toEqual([
+        'Unknown option: --nope. See --help for the flag list.',
+      ]);
+    });
+
+    it('still accepts a known flag', () => {
+      expect(parseArgs(['--quiet']).errors).toEqual([]);
+    });
+  });
+
   describe('--extensions and --max-depth', () => {
     it('normalizes a comma-separated extension list', () => {
       expect(opts('--extensions', 'ts,.tsx, js').extensions).toEqual(['.ts', '.tsx', '.js']);

--- a/packages/effect-analyzer/src/cli-options.ts
+++ b/packages/effect-analyzer/src/cli-options.ts
@@ -7,7 +7,7 @@
  */
 
 import { parseTsgoProjectArgument } from './tsgo-diagnostics';
-import { printHelp } from './cli-help';
+import { printHelp, printVersion } from './cli-help';
 import type { CouplingIssueType, CouplingPriorityMap } from './agent-report';
 import type { FailOnSeverity } from './lint-session';
 
@@ -256,6 +256,11 @@ export function parseArgs(args: readonly string[]): {
 
     if (arg === '--help' || arg === '-h') {
       printHelp();
+      process.exit(0);
+    }
+
+    if (arg === '--version' || arg === '-v') {
+      printVersion();
       process.exit(0);
     }
 
@@ -621,6 +626,8 @@ export function parseArgs(args: readonly string[]): {
       } else {
         rejectValue('--test-runner', value, TEST_RUNNER_VALUES);
       }
+    } else {
+      errors.push(`Unknown option: ${arg}. See --help for the flag list.`);
     }
   }
 

--- a/packages/effect-analyzer/src/cli.diagram-fidelity.test.ts
+++ b/packages/effect-analyzer/src/cli.diagram-fidelity.test.ts
@@ -33,4 +33,25 @@ describe('cli --assert-diagram-fidelity', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('fails when filtering left it nothing to assert', () => {
+    const root = mkdtempSync(join(tmpdir(), 'effect-fidelity-empty-'));
+    const sourceFile = join(root, 'program.ts');
+    writeFileSync(sourceFile, `
+      import { Effect } from "effect";
+      export const program = Effect.succeed(1);
+    `);
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [resolve('dist/cli.js'), sourceFile, '--assert-diagram-fidelity', '--quiet'],
+        { encoding: 'utf8' },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('checked no programs');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/effect-analyzer/src/error-flow.ts
+++ b/packages/effect-analyzer/src/error-flow.ts
@@ -44,6 +44,12 @@ export interface ErrorPropagationAnalysis {
 }
 
 export interface ErrorFlowAnalysis {
+  /**
+   * Every error type raised somewhere in the body, not the declared error
+   * channel of the program's signature. A step that raises `SchemaError` and
+   * maps it to `ValidationError` before returning is reported as `SchemaError`;
+   * for the channel, use `analyzeErrorChannels`.
+   */
   allErrors: string[];
   stepErrors: StepErrorInfo[];
   errorToSteps: Map<string, string[]>;

--- a/packages/effect-analyzer/src/output/mermaid-causes.ts
+++ b/packages/effect-analyzer/src/output/mermaid-causes.ts
@@ -1,19 +1,9 @@
 import { Option } from 'effect';
 import { getStaticChildren, type StaticEffectIR, type StaticFlowNode } from '../types';
-import { DEFAULT_LABEL_MAX, truncateDisplayText } from '../analysis-utils';
+import { DEFAULT_LABEL_MAX, escapeMermaidLabel as escapeLabel, truncateDisplayText } from '../analysis-utils';
 
 interface CausesOptions {
   readonly direction?: 'TB' | 'LR' | 'BT' | 'RL';
-}
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
 }
 
 /** Replace non-alphanumeric characters with underscores for Mermaid node IDs. */

--- a/packages/effect-analyzer/src/output/mermaid-concurrency.ts
+++ b/packages/effect-analyzer/src/output/mermaid-concurrency.ts
@@ -1,6 +1,6 @@
 import { Option } from 'effect';
 import { getStaticChildren, type StaticEffectIR, type StaticFlowNode } from '../types';
-import { DEFAULT_LABEL_MAX, truncateDisplayText } from '../analysis-utils';
+import { DEFAULT_LABEL_MAX, escapeMermaidLabel as escapeLabel, truncateDisplayText } from '../analysis-utils';
 
 interface ConcurrencyOptions {
   readonly direction?: 'TB' | 'LR' | 'BT' | 'RL';
@@ -11,16 +11,6 @@ type ConcurrencyNode =
   | { kind: 'race'; node: Extract<StaticFlowNode, { type: 'race' }> }
   | { kind: 'fiber'; node: Extract<StaticFlowNode, { type: 'fiber' }> }
   | { kind: 'primitive'; node: Extract<StaticFlowNode, { type: 'concurrency-primitive' }> };
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
-}
 
 /** Generate a short node ID. */
 function nodeId(prefix: string, index: number): string {

--- a/packages/effect-analyzer/src/output/mermaid-dataflow.ts
+++ b/packages/effect-analyzer/src/output/mermaid-dataflow.ts
@@ -1,5 +1,6 @@
 import { Option } from 'effect';
 import { getStaticChildren, type StaticEffectIR, type StaticFlowNode } from '../types';
+import { escapeMermaidLabel as escapeLabel } from '../analysis-utils';
 
 interface DataflowOptions {
   readonly direction?: 'TB' | 'LR' | 'BT' | 'RL';
@@ -15,16 +16,6 @@ interface DataflowStep {
 /** Generate a short node ID: S0, S1, S2, ... */
 function stepId(index: number): string {
   return `S${index}`;
-}
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
 }
 
 /**

--- a/packages/effect-analyzer/src/output/mermaid-decisions.ts
+++ b/packages/effect-analyzer/src/output/mermaid-decisions.ts
@@ -1,21 +1,12 @@
 import { Option } from 'effect';
 import { getStaticChildren, type StaticEffectIR, type StaticFlowNode } from '../types';
+import { escapeMermaidLabel as escapeLabel } from '../analysis-utils';
 
 interface DecisionsOptions {
   readonly direction?: 'TB' | 'LR' | 'BT' | 'RL';
 }
 
 const DECISION_TYPES = new Set(['conditional', 'decision', 'switch', 'match']);
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
-}
 
 /** Truncate text to a maximum length, appending ellipsis if needed. */
 function truncate(text: string, max = 40): string {

--- a/packages/effect-analyzer/src/output/mermaid-errors.ts
+++ b/packages/effect-analyzer/src/output/mermaid-errors.ts
@@ -1,20 +1,11 @@
 import type { StaticEffectIR } from '../types';
 import { analyzeErrorFlow } from '../error-flow';
 import { analyzeErrorPropagation } from '../error-flow';
+import { escapeMermaidLabel as escapeLabel } from '../analysis-utils';
 
 // =============================================================================
 // Helpers
 // =============================================================================
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
-}
 
 /** Replace non-alphanumeric characters with underscores for Mermaid node IDs. */
 function sanitizeId(text: string): string {

--- a/packages/effect-analyzer/src/output/mermaid-railway.ts
+++ b/packages/effect-analyzer/src/output/mermaid-railway.ts
@@ -1,5 +1,5 @@
 import { Option } from 'effect';
-import { DEFAULT_LABEL_MAX, truncateDisplayText } from '../analysis-utils';
+import { DEFAULT_LABEL_MAX, escapeMermaidLabel as escapeLabel, truncateDisplayText } from '../analysis-utils';
 import { getStaticChildren, type StaticEffectIR, type StaticFlowNode } from '../types';
 import { splitTopLevelUnion } from '../type-extractor';
 
@@ -17,16 +17,6 @@ function stepId(index: number): string {
   const letter = String.fromCharCode(65 + (index % 26));
   const cycle = Math.floor(index / 26);
   return cycle === 0 ? letter : `${letter}${cycle}`;
-}
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
 }
 
 /** Strip trailing "Error" or "Exception" suffix from a type name. */

--- a/packages/effect-analyzer/src/output/mermaid-retry.ts
+++ b/packages/effect-analyzer/src/output/mermaid-retry.ts
@@ -1,5 +1,6 @@
 import { Option } from 'effect';
 import { getStaticChildren, type StaticEffectIR, type StaticFlowNode, type StaticRetryNode, type StaticTimeoutNode } from '../types';
+import { escapeMermaidLabel as escapeLabel } from '../analysis-utils';
 
 interface RetryOptions {
   readonly direction?: 'TB' | 'LR' | 'BT' | 'RL';
@@ -8,16 +9,6 @@ interface RetryOptions {
 interface ResilienceNode {
   readonly node: StaticFlowNode;
   readonly index: number;
-}
-
-/** Escape characters that break Mermaid label syntax. */
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
 }
 
 /** Recursively collect retry and timeout nodes from the IR. */

--- a/packages/effect-analyzer/src/output/mermaid-services.ts
+++ b/packages/effect-analyzer/src/output/mermaid-services.ts
@@ -8,18 +8,10 @@
 
 import type { StaticEffectIR, ProjectServiceMap } from '../types';
 import { analyzeServiceFlow } from '../service-flow';
+import { escapeMermaidLabel as escapeLabel } from '../analysis-utils';
 
 interface ServicesOptions {
   readonly direction?: 'TB' | 'LR' | 'BT' | 'RL';
-}
-
-function escapeLabel(text: string): string {
-  return text
-    .replace(/"/g, '#quot;')
-    .replace(/</g, '#lt;')
-    .replace(/>/g, '#gt;')
-    .replace(/\(/g, '#lpar;')
-    .replace(/\)/g, '#rpar;');
 }
 
 function sanitizeId(text: string): string {

--- a/packages/effect-analyzer/src/output/mermaid.ts
+++ b/packages/effect-analyzer/src/output/mermaid.ts
@@ -136,7 +136,7 @@ interface RenderResult {
 
 function escapeLabel(label: string): string {
   return label
-    .replace(/\r?\n/g, ' ')
+    .replace(/\s+/g, ' ')
     .replace(/"/g, "'")
     .replace(/\[/g, '(')
     .replace(/\]/g, ')')


### PR DESCRIPTION
## Summary

- `--version`/`-v` prints the analyzer version, resolved through the package's own `./package.json` export so it works from `src` and `dist`.
- An argument starting with `-` that `parseArgs` does not claim is now an `Unknown option` error rather than a positional path.
- Mermaid node labels escape through a shared `escapeMermaidLabel` in `analysis-utils.ts` (replacing eight per-renderer copies) and collapse whitespace runs to a single space, so a label built from wrapped source stays on one line.
- `--assert-diagram-fidelity` requires at least one program to check.
- `analyze().single` names the programs it found and points at `.named()` and `.all`.
- `effect-analyzer/package.json` is exported; the `effect` peer range moves to `^4.0.0-rc.112`.

## Docs

CLI reference (`--version` row, unknown-flag rule), installation, diagram-fidelity precondition, API reference `.single` note, README, and the `effect-analyzer` skill.

## Test plan

- `pnpm build`, `pnpm type-check`, `pnpm lint` clean.
- `pnpm vitest run` — 105 files, 1582 tests passing.
- New coverage: `cli-options.test.ts` (unknown flag rejected, known flag still accepted) and `cli.diagram-fidelity.test.ts` (exits 1 when filtering leaves nothing to assert).